### PR TITLE
Improvements for cellery syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ VERSION ?= $(GIT_REVISION)
 # Go build time flags
 GO_LDFLAGS := -X $(PROJECT_PKG)/components/cli/pkg/version.buildVersion=$(VERSION)
 GO_LDFLAGS += -X $(PROJECT_PKG)/components/cli/pkg/version.buildGitRevision=$(GIT_REVISION)
-GO_LDFLAGS += -X $(PROJECT_PKG)/components/cli/pkg/version.buildTime=$(shell date --iso=seconds)
+GO_LDFLAGS += -X $(PROJECT_PKG)/components/cli/pkg/version.buildTime=$(shell date +%Y-%m-%dT%H:%M:%S%z)
 
 all: code.format build-lang build-cli
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ cellery:Component helloWorldComp = {
     }
 };
 
-public cellery:CellImage helloCell = new();
+cellery:CellImage helloCell = new();
 
 public function build(string orgName, string imageName, string imageVersion) {
     helloCell.addComponent(helloWorldComp);

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ public cellery:CellImage helloCell = new();
 public function build(string orgName, string imageName, string imageVersion) {
     helloCell.addComponent(helloWorldComp);
 
-    helloCell.exposeGlobalAPI(helloWorldComp);
+    helloCell.exposeGlobal(helloWorldComp);
 
     var out = cellery:createImage(helloCell, orgName, imageName, imageVersion);
     if (out is boolean) {

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ cellery:Component helloWorldComp = {
         image: "sumedhassk/hello-world:1.0.0"
     },
     ingresses: {
-        hello: new cellery:HTTPIngress(
+        hello: new cellery:HttpApiIngress(
                    9090,
 
                    "hello",

--- a/components/cli/pkg/commands/init.go
+++ b/components/cli/pkg/commands/init.go
@@ -68,7 +68,7 @@ func RunInit() {
 		"        image: \"sumedhassk/hello-world:1.0.0\"\n" +
 		"    },\n" +
 		"    ingresses: {\n" +
-		"        hello: new cellery:HTTPIngress(\n" +
+		"        hello: new cellery:HttpApiIngress(\n" +
 		"                   9090,\n" +
 		"\n" +
 		"                   \"hello\",\n" +

--- a/components/cli/pkg/commands/init.go
+++ b/components/cli/pkg/commands/init.go
@@ -60,8 +60,7 @@ func RunInit() {
 		util.ExitWithErrorMessage("Error occurred while initializing the project", err)
 	}
 
-	cellTemplate := "import ballerina/io;\n" +
-		"import celleryio/cellery;\n" +
+	cellTemplate := "import celleryio/cellery;\n" +
 		"\n" +
 		"cellery:Component helloWorldComp = {\n" +
 		"    name: \"hello-world\",\n" +
@@ -84,17 +83,14 @@ func RunInit() {
 		"    }\n" +
 		"};\n" +
 		"\n" +
-		"public cellery:CellImage helloCell = new();\n" +
+		"cellery:CellImage helloCell = new();\n" +
 		"\n" +
 		"public function build(string orgName, string imageName, string imageVersion) {\n" +
 		"    helloCell.addComponent(helloWorldComp);\n" +
 		"\n" +
 		"    helloCell.exposeGlobal(helloWorldComp);\n" +
 		"\n" +
-		"    var out = cellery:createImage(helloCell, orgName, imageName, imageVersion);\n" +
-		"    if (out is boolean) {\n" +
-		"        io:println(\"Hello World Cell Built successfully.\");\n" +
-		"    }\n" +
+		"    _= cellery:createImage(helloCell, orgName, imageName, imageVersion);\n" +
 		"}\n" +
 		"\n"
 

--- a/components/cli/pkg/commands/init.go
+++ b/components/cli/pkg/commands/init.go
@@ -89,7 +89,7 @@ func RunInit() {
 		"public function build(string orgName, string imageName, string imageVersion) {\n" +
 		"    helloCell.addComponent(helloWorldComp);\n" +
 		"\n" +
-		"    helloCell.exposeGlobalAPI(helloWorldComp);\n" +
+		"    helloCell.exposeGlobal(helloWorldComp);\n" +
 		"\n" +
 		"    var out = cellery:createImage(helloCell, orgName, imageName, imageVersion);\n" +
 		"    if (out is boolean) {\n" +

--- a/components/lang/src/main/ballerina/celleryio/cellery/natives.bal
+++ b/components/lang/src/main/ballerina/celleryio/cellery/natives.bal
@@ -172,7 +172,10 @@ public type CellImage object {
         self.components[self.components.length()] = component;
     }
 
-    public function exposeAPIsFrom(Component component) {
+    # Expose the all the ingresses in a component via Cell Gateway
+    #
+    # + component - The component record
+    public function exposeLocal(Component component) {
         foreach var (name, ingressTemp) in component.ingresses {
             if (ingressTemp is HTTPIngress) {
                 self.apis[self.apis.length()] = {
@@ -189,7 +192,11 @@ public type CellImage object {
         }
     }
 
-    public function exposeAPIFrom(Component component, string ingressName) {
+    # Expose a given ingress via Cell Gateway
+    #
+    # + component - The component record
+    # + ingressName - Name of the ingress to be exposed
+    public function exposeIngressLocal(Component component, string ingressName) {
         TCPIngress|HTTPIngress? ingress = component.ingresses[ingressName];
         if (ingress is HTTPIngress) {
             self.apis[self.apis.length()] = {
@@ -209,6 +216,9 @@ public type CellImage object {
         }
     }
 
+    # Expose the all the ingresses in a component via Global Gateway
+    #
+    # + component - The component record
     public function exposeGlobal(Component component) {
         foreach var (name, ingressTemp) in component.ingresses {
             if (ingressTemp is HTTPIngress) {
@@ -218,6 +228,30 @@ public type CellImage object {
                     global: true
                 };
             }
+        }
+    }
+
+    # Expose a given ingress via Global Cell Gateway
+    #
+    # + component - The component record
+    # + ingressName - Name of the ingress to be exposed
+    public function exposeIngressGlobal(Component component, string ingressName) {
+        TCPIngress|HTTPIngress? ingress = component.ingresses[ingressName];
+        if (ingress is HTTPIngress) {
+            self.apis[self.apis.length()] = {
+                targetComponent: component.name,
+                ingress: ingress,
+                global: true
+            };
+        } else if (ingress is TCPIngress){
+            self.tcp[self.tcp.length()] = {
+                targetComponent: component.name,
+                ingress: ingress
+            };
+        }
+        else {
+            error err = error("Ingress " + ingressName + " not found in the component " + component.name + ".");
+            panic err;
         }
     }
 

--- a/components/lang/src/main/ballerina/celleryio/cellery/natives.bal
+++ b/components/lang/src/main/ballerina/celleryio/cellery/natives.bal
@@ -49,7 +49,7 @@ public type API record {
     string name?;
     string targetComponent;
     boolean global;
-    HTTPIngress ingress;
+    HttpApiIngress ingress;
     !...;
 };
 
@@ -102,7 +102,7 @@ public type Component record {
     string name;
     ImageSource source;
     int replicas = 1;
-    map<TCPIngress|HTTPIngress> ingresses?;
+    map<TCPIngress|HttpApiIngress> ingresses?;
     map<string> labels?;
     map<Env|Secret> parameters?;
     AutoScaling autoscaling?;
@@ -118,7 +118,7 @@ public type TCPIngress object {
     }
 };
 
-public type HTTPIngress object {
+public type HttpApiIngress object {
     public int port;
     public string context;
     public Definition[] definitions;
@@ -177,7 +177,7 @@ public type CellImage object {
     # + component - The component record
     public function exposeLocal(Component component) {
         foreach var (name, ingressTemp) in component.ingresses {
-            if (ingressTemp is HTTPIngress) {
+            if (ingressTemp is HttpApiIngress) {
                 self.apis[self.apis.length()] = {
                     targetComponent: component.name,
                     ingress: ingressTemp,
@@ -197,8 +197,8 @@ public type CellImage object {
     # + component - The component record
     # + ingressName - Name of the ingress to be exposed
     public function exposeIngressLocal(Component component, string ingressName) {
-        TCPIngress|HTTPIngress? ingress = component.ingresses[ingressName];
-        if (ingress is HTTPIngress) {
+        TCPIngress|HttpApiIngress? ingress = component.ingresses[ingressName];
+        if (ingress is HttpApiIngress) {
             self.apis[self.apis.length()] = {
                 targetComponent: component.name,
                 ingress: ingress,
@@ -221,7 +221,7 @@ public type CellImage object {
     # + component - The component record
     public function exposeGlobal(Component component) {
         foreach var (name, ingressTemp) in component.ingresses {
-            if (ingressTemp is HTTPIngress) {
+            if (ingressTemp is HttpApiIngress) {
                 self.apis[self.apis.length()] = {
                     targetComponent: component.name,
                     ingress: ingressTemp,
@@ -236,8 +236,8 @@ public type CellImage object {
     # + component - The component record
     # + ingressName - Name of the ingress to be exposed
     public function exposeIngressGlobal(Component component, string ingressName) {
-        TCPIngress|HTTPIngress? ingress = component.ingresses[ingressName];
-        if (ingress is HTTPIngress) {
+        TCPIngress|HttpApiIngress? ingress = component.ingresses[ingressName];
+        if (ingress is HttpApiIngress) {
             self.apis[self.apis.length()] = {
                 targetComponent: component.name,
                 ingress: ingress,

--- a/components/lang/src/main/ballerina/celleryio/cellery/natives.bal
+++ b/components/lang/src/main/ballerina/celleryio/cellery/natives.bal
@@ -209,7 +209,7 @@ public type CellImage object {
         }
     }
 
-    public function exposeGlobalAPI(Component component) {
+    public function exposeGlobal(Component component) {
         foreach var (name, ingressTemp) in component.ingresses {
             if (ingressTemp is HTTPIngress) {
                 self.apis[self.apis.length()] = {

--- a/docs/cell-reference.md
+++ b/docs/cell-reference.md
@@ -21,7 +21,7 @@ cellery:Component stock = {
        image: "docker.io/celleryio/sampleapp-stock"
    },
    ingresses: {
-       stock: new cellery:HTTPIngress(8080,
+       stock: new cellery:HttpApiIngress(8080,
            "stock",
            [
                {
@@ -41,7 +41,7 @@ An Ingress represents an entry point into a Cell or Component. An ingress can be
 HTTP ingress supports defining HTTP definitions inline or as a swagger file.
 A sample ingress instance  with inline API definition would be as follows:
 ```
-cellery:Ingress ingressA = new cellery:HTTPIngress(
+cellery:Ingress ingressA = new cellery:HttpApiIngress(
     8080,      //port
     "foo",        //context
      [        // Definitions
@@ -54,7 +54,7 @@ cellery:Ingress ingressA = new cellery:HTTPIngress(
 ```
 A sample ingress instance  with swagger 2.0 definition would be as follows:
 ```
-cellery:Ingress ingressA = new cellery:HTTPIngress(
+cellery:Ingress ingressA = new cellery:HttpApiIngress(
     8080,
     "foo",
     “./resources/employee.swagger.json”
@@ -81,7 +81,7 @@ cellery:Component employeeComponent = {
        image: "docker.io/celleryio/sampleapp-employee"
    },
    ingresses: {
-       employee: new cellery:HTTPIngress(
+       employee: new cellery:HttpApiIngress(
                      8080,
                      "employee",
                      "./resources/employee.swagger.json"
@@ -124,7 +124,7 @@ cellery:Component stock = {
        image: "docker.io/celleryio/sampleapp-stock"
    },
    ingresses: {
-       stock: new cellery:HTTPIngress(8080,
+       stock: new cellery:HttpApiIngress(8080,
            "stock",
            [
                {
@@ -173,7 +173,7 @@ cellery:Component stock = {
        image: "docker.io/celleryio/sampleapp-stock"
    },
    ingresses: {
-       stock: new cellery:HTTPIngress(8080,
+       stock: new cellery:HttpApiIngress(8080,
            "stock",
            [
                {
@@ -214,7 +214,7 @@ cellery:Component employeeComponent = {
        image: "docker.io/celleryio/sampleapp-employee"
    },
    ingresses: {
-       employee: new cellery:HTTPIngress(
+       employee: new cellery:HttpApiIngress(
                      8080,
                      "employee",
                      "./resources/employee.swagger.json"
@@ -238,7 +238,7 @@ cellery:Component salaryComponent = {
        image: "docker.io/celleryio/sampleapp-salary"
    },
    ingresses: {
-       SalaryAPI: new cellery:HTTPIngress(
+       SalaryAPI: new cellery:HttpApiIngress(
                8080,
                "payroll",
                [{
@@ -348,7 +348,7 @@ cellery:Component hrComponent = {
       image: "docker.io/wso2vick/sampleapp-hr"
   },
   ingresses: {
-      hr: new cellery:HTTPIngress(8080, "info",
+      hr: new cellery:HttpApiIngress(8080, "info",
           [
               {
                   path: "/",

--- a/docs/cell-reference.md
+++ b/docs/cell-reference.md
@@ -108,7 +108,7 @@ public function build(string orgName, string imageName, string imageVersion) {
    // Add components to Cell
    employeeCell.addComponent(employeeComponent);
    //Expose API from Cell Gateway
-   employeeCell.exposeAPIsFrom(employeeComponent);
+   employeeCell.exposeLocal(employeeComponent);
 
    _ = cellery:createImage(employeeCell, orgName, imageName, imageVersion);
 }
@@ -116,7 +116,7 @@ public function build(string orgName, string imageName, string imageVersion) {
 
 #### APIs
 An API represents a defined set of functions and procedures that the services of the Components inside a Cell exposes 
-as resources (i.e ingresses). An Ingress can be exposed as an API using exposeAPIsFrom method.
+as resources (i.e ingresses). An Ingress can be exposed as an API using exposeLocal method.
 ```
 cellery:Component stock = {
    name: "stock",
@@ -143,7 +143,7 @@ public function build(string orgName, string imageName, string imageVersion) {
    io:println("Building Stock Cell ...");
    stockCell.addComponent(stock);
    //Expose API from Cell Gateway
-   stockCell.exposeAPIsFrom(stock);
+   stockCell.exposeLocal(stock);
    _ = cellery:createImage(stockCell, orgName, imageName, imageVersion);
 }
 ```
@@ -193,7 +193,7 @@ public function build(string orgName, string imageName, string imageVersion) {
    io:println("Building Stock Cell ...");
    stockCell.addComponent(stock);
    //Expose API from Cell Gateway
-   stockCell.exposeAPIsFrom(stock);
+   stockCell.exposeLocal(stock);
    _ = cellery:createImage(stockCell, orgName, imageName, imageVersion);
 }
 ```
@@ -261,7 +261,7 @@ public function build(string orgName, string imageName, string imageVersion) {
    // Add components to Cell
    employeeCell.addComponent(employeeComponent);
    //Expose API from Cell Gateway
-   employeeCell.exposeAPIsFrom(employeeComponent);
+   employeeCell.exposeLocal(employeeComponent);
 
    _ = cellery:createImage(employeeCell, orgName, imageName, imageVersion);
 }

--- a/samples/employee-portal/cellery/employee/employee.bal
+++ b/samples/employee-portal/cellery/employee/employee.bal
@@ -8,7 +8,7 @@ cellery:Component employeeComponent = {
         image: "docker.io/celleryio/sampleapp-employee"
     },
     ingresses: {
-        employee: new cellery:HTTPIngress(
+        employee: new cellery:HttpApiIngress(
                       8080,
                       "employee",
                       "./resources/employee.swagger.json"
@@ -30,7 +30,7 @@ cellery:Component salaryComponent = {
         image: "docker.io/celleryio/sampleapp-salary"
     },
     ingresses: {
-        SalaryAPI: new cellery:HTTPIngress(
+        SalaryAPI: new cellery:HttpApiIngress(
                 8080,
                 "payroll",
                 [{

--- a/samples/employee-portal/cellery/employee/employee.bal
+++ b/samples/employee-portal/cellery/employee/employee.bal
@@ -60,7 +60,7 @@ public function build(string orgName, string imageName, string imageVersion) {
     employeeCell.addComponent(salaryComponent);
 
     //Expose API from Cell Gateway
-    employeeCell.exposeAPIsFrom(employeeComponent);
+    employeeCell.exposeLocal(employeeComponent);
 
     _ = cellery:createImage(employeeCell, orgName, imageName, imageVersion);
 }

--- a/samples/employee-portal/cellery/employee/employee.bal
+++ b/samples/employee-portal/cellery/employee/employee.bal
@@ -45,7 +45,7 @@ cellery:Component salaryComponent = {
     }
 };
 
-public cellery:CellImage employeeCell = new();
+cellery:CellImage employeeCell = new();
 
 public function build(string orgName, string imageName, string imageVersion) {
 

--- a/samples/employee-portal/cellery/hr/hr.bal
+++ b/samples/employee-portal/cellery/hr/hr.bal
@@ -36,7 +36,7 @@ public function build(string orgName, string imageName, string imageVersion) {
     hrCell.addComponent(hrComponent);
 
     // Expose API from Cell Gateway & Global Gateway
-    hrCell.exposeGlobalAPI(hrComponent);
+    hrCell.exposeGlobal(hrComponent);
     _ = cellery:createImage(hrCell, orgName, imageName, imageVersion);
 }
 

--- a/samples/employee-portal/cellery/hr/hr.bal
+++ b/samples/employee-portal/cellery/hr/hr.bal
@@ -11,7 +11,7 @@ cellery:Component hrComponent = {
         image: "docker.io/celleryio/sampleapp-hr"
     },
     ingresses: {
-        "hr": new cellery:HTTPIngress(
+        "hr": new cellery:HttpApiIngress(
                   8080,
                   "hr-api",
                   [{

--- a/samples/employee-portal/cellery/mysql/mysql.bal
+++ b/samples/employee-portal/cellery/mysql/mysql.bal
@@ -22,6 +22,6 @@ public function build(string orgName, string imageName, string imageVersion) {
     io:println("Building MySQL Cell ...");
     mysqlCell.addComponent(mysqlComponent);
     //Expose API from Cell Gateway
-    mysqlCell.exposeAPIsFrom(mysqlComponent);
+    mysqlCell.exposeLocal(mysqlComponent);
     _ = cellery:createImage(mysqlCell, orgName, imageName, imageVersion);
 }

--- a/samples/employee-portal/cellery/stock/stocks.bal
+++ b/samples/employee-portal/cellery/stock/stocks.bal
@@ -27,6 +27,6 @@ public function build(string orgName, string imageName, string imageVersion) {
     io:println("Building Stock Cell ...");
     stockCell.addComponent(stock);
     //Expose API from Cell Gateway
-    stockCell.exposeAPIsFrom(stock);
+    stockCell.exposeLocal(stock);
     _ = cellery:createImage(stockCell, orgName, imageName, imageVersion);
 }

--- a/samples/employee-portal/cellery/stock/stocks.bal
+++ b/samples/employee-portal/cellery/stock/stocks.bal
@@ -8,7 +8,7 @@ cellery:Component stock = {
         image: "docker.io/celleryio/sampleapp-stock"
     },
     ingresses: {
-        stock: new cellery:HTTPIngress(8080,
+        stock: new cellery:HttpApiIngress(8080,
             "stock",
             [
                 {

--- a/samples/pet-service/pet-cell.bal
+++ b/samples/pet-service/pet-cell.bal
@@ -44,7 +44,7 @@ public function build(string orgName, string imageName, string imageVersion) {
     io:println("Building Pet Service Cell ...");
     petCell.addComponent(petComponent);
     petCell.addComponent(debugComponent);
-    //Expose API from Cell Gateway
-    petCell.exposeGlobalAPI(petComponent);
+    //Expose API from Global Cell Gateway
+    petCell.exposeGlobal(petComponent);
     _ = cellery:createImage(petCell, orgName, imageName, imageVersion);
 }

--- a/samples/pet-service/pet-cell.bal
+++ b/samples/pet-service/pet-cell.bal
@@ -8,7 +8,7 @@ cellery:Component petComponent = {
         image: "docker.io/isurulucky/pet-service"
     },
     ingresses: {
-        stock: new cellery:HTTPIngress(9090,
+        stock: new cellery:HttpApiIngress(9090,
             "petsvc",
             [
                 {

--- a/samples/pet-store/backend/pet-be.bal
+++ b/samples/pet-store/backend/pet-be.bal
@@ -122,7 +122,7 @@ public function build(string orgName, string imageName, string imageVersion) {
     cellery:setParameter(controllerComponent.parameters.CUSTOMER_PORT, customerPort);
 
     //Expose API from Cell Gateway
-    petStoreCell.exposeAPIsFrom(controllerComponent);
+    petStoreCell.exposeLocal(controllerComponent);
 
     _ = cellery:createImage(petStoreCell, orgName, imageName, imageVersion);
 }

--- a/samples/pet-store/backend/pet-be.bal
+++ b/samples/pet-store/backend/pet-be.bal
@@ -29,7 +29,7 @@ cellery:Component ordersComponent = {
         image: "celleryio/samples-pet-store-orders"
     },
     ingresses: {
-        orders: new cellery:HTTPIngress(orderPort,
+        orders: new cellery:HttpApiIngress(orderPort,
             "orders",
             [
                 {
@@ -48,7 +48,7 @@ cellery:Component customersComponent = {
         image: "celleryio/samples-pet-store-customers"
     },
     ingresses: {
-        customers: new cellery:HTTPIngress(customerPort,
+        customers: new cellery:HttpApiIngress(customerPort,
             "customers",
             [
                 {
@@ -67,7 +67,7 @@ cellery:Component catalogComponent = {
         image: "celleryio/samples-pet-store-catalog"
     },
     ingresses: {
-        catalog: new cellery:HTTPIngress(catalogPort,
+        catalog: new cellery:HttpApiIngress(catalogPort,
             "catalog",
             [
                 {
@@ -86,7 +86,7 @@ cellery:Component controllerComponent = {
         image: "celleryio/samples-pet-store-controller"
     },
     ingresses: {
-        controller: new cellery:HTTPIngress(
+        controller: new cellery:HttpApiIngress(
                       controllerPort,
                       "controller",
                       "./components/controller/resources/pet-store.swagger.json"


### PR DESCRIPTION
## Purpose
- Rename exposeGlobalAPI -> exposeGlobal (Resolves https://github.com/wso2-cellery/sdk/issues/115) 
- Refactor generated code from cellery init (Resolves https://github.com/wso2-cellery/sdk/issues/113)
- Fix Makefile date command on MacOS 
- Rename exposeIngressFrom -> exposeLocal (Resolves https://github.com/wso2-cellery/sdk/issues/115)
- Rename HttpApiIngress (Resolves https://github.com/wso2-cellery/sdk/issues/114)
- Remove public access modifier from samples (Resolves https://github.com/wso2-cellery/sdk/issues/117)