### PR TITLE
Add CIL setup option to delete GCP cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $ cellery init
 What's next?
 --------------------------------------------------------
 Execute the following command to build the image:
-  $ cellery build helloworld/helloworld.bal -t [repo/]organization/image_name:version
+  $ cellery build helloworld/helloworld.bal [repo/]organization/image_name:version
 --------------------------------------------------------
 ```
 2. The above step will auto generate a cellery file in the location: helloworld/helloworld.bal with below content. 
@@ -187,7 +187,7 @@ public function build(string orgName, string imageName, string imageVersion) {
 
 3. Build the cellery image for hello world project by executing the cellery build command as shown below.
 ```
-$ cellery build helloworld.bal -t myorg/helloworld:1.0.0
+$ cellery build helloworld.bal myorg/helloworld:1.0.0
 Hello World Cell Built successfully.
 
 ✔ Building image myorg/helloworld:1.0.0

--- a/components/cli/pkg/commands/init.go
+++ b/components/cli/pkg/commands/init.go
@@ -127,5 +127,5 @@ func RunInit() {
 
 	util.PrintSuccessMessage(fmt.Sprintf("Initialized project in directory: %s", util.Faint(projectDir)))
 	util.PrintWhatsNextMessage("build the image",
-		"cellery build "+projectName+"/"+projectName+".bal"+" -t [repo/]organization/image_name:version")
+		"cellery build "+projectName+"/"+projectName+".bal"+" [repo/]organization/image_name:version")
 }

--- a/components/cli/pkg/commands/run.go
+++ b/components/cli/pkg/commands/run.go
@@ -144,7 +144,7 @@ func RunRun(cellImageTag string, instanceName string, dependencies []string) {
 	}
 
 	util.PrintSuccessMessage(fmt.Sprintf("Successfully deployed cell image: %s", util.Bold(cellImageTag)))
-	util.PrintWhatsNextMessage("list running cells", "cellery ps")
+	util.PrintWhatsNextMessage("list running cells", "cellery list instances")
 }
 
 func buildCommand(name string, args []string) (*exec.Cmd, error) {

--- a/components/cli/pkg/commands/setup.go
+++ b/components/cli/pkg/commands/setup.go
@@ -283,6 +283,41 @@ func manageEnvironment() error {
 	}
 
 	cellPrompt := promptui.Select{
+		Label:     util.YellowBold("?") + " Select a runtime",
+		Items:     []string{constants.CELLERY_CREATE_LOCAL, constants.CELLERY_CREATE_GCP, constants.CELLERY_SETUP_BACK},
+		Templates: cellTemplate,
+	}
+	_, value, err := cellPrompt.Run()
+	if err != nil {
+		return fmt.Errorf("Failed to install environment: %v", err)
+	}
+
+	switch value {
+	case constants.CELLERY_CREATE_LOCAL:
+		{
+			manageLocal()
+		}
+	case constants.CELLERY_CREATE_GCP:
+		{
+			manageGcp()
+		}
+	default:
+		{
+			RunSetup()
+		}
+	}
+	return nil
+}
+
+func manageLocal() error {
+	cellTemplate := &promptui.SelectTemplates{
+		Label:    "{{ . }}",
+		Active:   "\U000027A4 {{ .| bold }}",
+		Inactive: "  {{ . | faint }}",
+		Help:     util.Faint("[Use arrow keys]"),
+	}
+
+	cellPrompt := promptui.Select{
 		Label:     util.YellowBold("?") + " " + getManageLabel(),
 		Items:     getManageEnvOptions(),
 		Templates: cellTemplate,
@@ -307,22 +342,42 @@ func manageEnvironment() error {
 		}
 	case constants.CELLERY_MANAGE_CLEANUP:
 		{
-			spinner := util.StartNewSpinner("Removing Cellery Runtime")
-			defer func() {
-				spinner.Stop(true)
-			}()
-			if isVmRuning() {
-				util.ExecuteCommand(exec.Command(constants.VBOX_MANAGE, "controlvm", constants.VM_NAME, "acpipowerbutton"), "Error stopping VM")
-			}
-			for isVmRuning() {
-				time.Sleep(2 * time.Second)
-			}
-			util.ExecuteCommand(exec.Command(constants.VBOX_MANAGE, "unregistervm", constants.VM_NAME, "--delete"), "Error deleting VM")
-			os.RemoveAll(filepath.Join(util.UserHomeDir(), constants.CELLERY_HOME, constants.VM, constants.AWS_S3_ITEM_VM))
+			cleanupLocal()
 		}
 	default:
 		{
-			RunSetup()
+			manageEnvironment()
+		}
+	}
+	return nil
+}
+
+func manageGcp() error {
+	cellTemplate := &promptui.SelectTemplates{
+		Label:    "{{ . }}",
+		Active:   "\U000027A4 {{ .| bold }}",
+		Inactive: "  {{ . | faint }}",
+		Help:     util.Faint("[Use arrow keys]"),
+	}
+
+	cellPrompt := promptui.Select{
+		Label:     util.YellowBold("?") + " Select `cleanup` to remove an existing GCP cluster",
+		Items:     []string{constants.CELLERY_MANAGE_CLEANUP, constants.CELLERY_SETUP_BACK},
+		Templates: cellTemplate,
+	}
+	_, value, err := cellPrompt.Run()
+	if err != nil {
+		return fmt.Errorf("Failed to install environment: %v", err)
+	}
+
+	switch value {
+	case constants.CELLERY_MANAGE_CLEANUP:
+		{
+			cleanupGcp()
+		}
+	default:
+		{
+			manageEnvironment()
 		}
 	}
 	return nil
@@ -539,7 +594,7 @@ func createGcp() error {
 
 	// Create bucket
 	gcpSpinner.SetNewAction("Creating gcp bucket")
-	if err := create(client, projectName, gcpBucketName); err != nil {
+	if err := createGcpStorage(client, projectName, gcpBucketName); err != nil {
 		gcpSpinner.Stop(false)
 		fmt.Printf("Error creating storage client: %v", err)
 	}
@@ -716,7 +771,7 @@ func createSqlInstance(ctx context.Context, service *sqladmin.Service, projectId
 	return nil, nil
 }
 
-func create(client *storage.Client, projectID, bucketName string) error {
+func createGcpStorage(client *storage.Client, projectID, bucketName string) error {
 	ctx := context.Background()
 	if err := client.Bucket(bucketName).Create(ctx, projectID, nil); err != nil {
 		return err
@@ -976,4 +1031,213 @@ func validateGcpConfigFile(configFiles []string) error {
 		}
 	}
 	return nil
+}
+
+func cleanupLocal() error {
+	spinner := util.StartNewSpinner("Removing Cellery Runtime")
+	defer func() {
+		spinner.Stop(true)
+	}()
+	if isVmRuning() {
+		util.ExecuteCommand(exec.Command(constants.VBOX_MANAGE, "controlvm", constants.VM_NAME, "acpipowerbutton"), "Error stopping VM")
+	}
+	for isVmRuning() {
+		time.Sleep(2 * time.Second)
+	}
+	util.ExecuteCommand(exec.Command(constants.VBOX_MANAGE, "unregistervm", constants.VM_NAME, "--delete"), "Error deleting VM")
+	os.RemoveAll(filepath.Join(util.UserHomeDir(), constants.CELLERY_HOME, constants.VM, constants.AWS_S3_ITEM_VM))
+	return nil
+}
+
+func cleanupGcp() error {
+	jsonAuthFile := util.FindInDirectory(filepath.Join(util.UserHomeDir(), constants.CELLERY_HOME, constants.GCP), ".json")
+
+	if len(jsonAuthFile) > 0 {
+		os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", jsonAuthFile[0])
+	} else {
+		fmt.Printf("Could not find authentication json file in : %v", filepath.Join(util.UserHomeDir(), constants.CELLERY_HOME, constants.GCP))
+		os.Exit(1)
+	}
+	ctx := context.Background()
+	projectName, accountName, region, zone = getGcpData()
+	gkeClient, err := google.DefaultClient(ctx, container.CloudPlatformScope)
+	if err != nil {
+		fmt.Printf("Failed to create gke client: %v", err)
+	}
+
+	gcpService, err := container.New(gkeClient)
+	if err != nil {
+		fmt.Printf("Failed to create gcp service: %v", err)
+	}
+
+	clusters, err := getClusterList(gcpService, projectName, zone)
+	if err != nil {
+		fmt.Printf("Failed to list clusters: %v", err)
+	}
+
+	selectTemplate := &promptui.SelectTemplates{
+		Label:    "{{ . }}",
+		Active:   "\U000027A4 {{ .| bold }}",
+		Inactive: "  {{ . | faint }}",
+		Help:     util.Faint("[Use arrow keys]"),
+	}
+
+	cellPrompt := promptui.Select{
+		Label:     util.YellowBold("?") + " Select a GCP cluster to delete",
+		Items:     append(clusters, constants.CELLERY_SETUP_BACK),
+		Templates: selectTemplate,
+	}
+	_, value, err := cellPrompt.Run()
+	if err != nil {
+		util.ExitWithErrorMessage("Failed to select an option: %v", err)
+	}
+	if value == constants.CELLERY_SETUP_BACK {
+		manageGcp()
+	}
+
+	// Get the suffix - unique number of GCP cluster which is common to all infrastructures (sql instance, filestore, bucket)
+	uniqueNumber := strings.TrimPrefix(value, "cellery-cluster")
+
+	cleanupSpinner := util.StartNewSpinner("Removing GCP cluster")
+
+	// Delete GCP cluster
+	errCleanup := deleteGcpCluster(gcpService, projectName, zone, constants.GCP_CLUSTER_NAME + uniqueNumber)
+	if errCleanup != nil {
+		cleanupSpinner.Stop(false)
+		fmt.Printf("Failed to cleanup GCP cluster: %v", errCleanup)
+	}
+	for i := 0; i < 15; i++ {
+		if gcpClusterExist(gcpService, projectName, zone, constants.GCP_CLUSTER_NAME + uniqueNumber) {
+			time.Sleep(60 * time.Second)
+		} else {
+			break
+		}
+	}
+	// Delete sql instance
+	cleanupSpinner.SetNewAction("Deleting sql instance")
+	hcSql, err := google.DefaultClient(ctx, sqladmin.CloudPlatformScope)
+
+	if err != nil {
+		cleanupSpinner.Stop(false)
+		fmt.Printf("Failed to cleanup GCP cluster: %v", err)
+	}
+
+	sqlService, err := sqladmin.New(hcSql)
+	if err != nil {
+		cleanupSpinner.Stop(false)
+		fmt.Printf("Failed to cleanup GCP cluster: %v", err)
+	}
+
+	errorDeleteSql := deleteSqlInstance(sqlService, projectName, constants.GCP_DB_INSTANCE_NAME + uniqueNumber)
+	if errorDeleteSql != nil {
+		cleanupSpinner.Stop(false)
+		fmt.Printf("Failed to cleanup GCP cluster: %v", errorDeleteSql)
+	}
+
+	// Delete nfs file server
+	cleanupSpinner.SetNewAction("Deleting File store")
+	hcNfs, err := google.DefaultClient(ctx, file.CloudPlatformScope)
+	if err != nil {
+		cleanupSpinner.Stop(false)
+		fmt.Printf("Failed to cleanup GCP cluster: %v", err)
+	}
+
+	nfsService, err := file.New(hcNfs)
+	if err != nil {
+		cleanupSpinner.Stop(false)
+		fmt.Printf("Failed to cleanup GCP cluster: %v", err)
+	}
+	errDeleteFileStore := deleteFileStore(nfsService, projectName, zone, constants.GCP_NFS_SERVER_INSTANCE + uniqueNumber)
+	if errDeleteFileStore != nil {
+		fmt.Printf("Failed to cleanup GCP cluster: %v", errDeleteFileStore)
+	}
+
+	// Delete GCP storage
+	cleanupSpinner.SetNewAction("Deleting Storage")
+	storageClient, err := storage.NewClient(ctx)
+	if err != nil {
+		fmt.Printf("Error creating storage client: %v", err)
+	}
+
+	errorDeleteStorageObject := deleteGcpStorageObject(storageClient, constants.GCP_BUCKET_NAME + uniqueNumber, constants.INIT_SQL)
+	if err != nil {
+		fmt.Printf("Error deleting gcp storage object: %v", errorDeleteStorageObject)
+	}
+
+	errorDeleteStorage := deleteGcpStorage(storageClient, constants.GCP_BUCKET_NAME + uniqueNumber)
+	if err != nil {
+		fmt.Printf("Error deleting gcp storage: %v", errorDeleteStorage)
+	}
+
+	cleanupSpinner.Stop(true)
+	return nil
+}
+
+func deleteGcpCluster(gcpService *container.Service, projectID string, zone string, clusterID string) error {
+	_, err := gcpService.Projects.Zones.Clusters.Delete(projectID,zone, clusterID).Do()
+	if err != nil {
+		return fmt.Errorf("failed to delete gcp cluster: %v", err)
+
+	}
+	return nil
+}
+
+func deleteSqlInstance(service *sqladmin.Service, projectId string, instanceName string) error {
+	_, err := service.Instances.Delete(projectId,instanceName).Do()
+	if err != nil {
+		return fmt.Errorf("failed to delete the sql instance: %v", err)
+	}
+	return nil
+}
+
+func deleteFileStore(service *file.Service, projectName, zone, storeName string) error {
+	_, err := service.Projects.Locations.Instances.Delete("projects/"+projectName+"/locations/"+zone + "/instances/" + storeName).Do()
+	if err != nil {
+		return fmt.Errorf("failed to delete nfs server %v", err)
+	}
+	return nil
+}
+
+func deleteGcpStorage(client *storage.Client, bucketName string) error {
+	ctx := context.Background()
+	if err := client.Bucket(bucketName).Delete(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deleteGcpStorageObject(client *storage.Client, bucketName, objectName string) error {
+	ctx := context.Background()
+	object := client.Bucket(bucketName).Object(objectName)
+	if err := object.Delete(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getClusterList(service *container.Service, projectID, zone string) ([]string, error) {
+	var clusters []string
+	list, err := service.Projects.Zones.Clusters.List(projectID, zone).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list clusters: %v", err)
+	}
+
+	for _, cluster := range list.Clusters {
+		clusters = append(clusters, cluster.Name)
+	}
+	return clusters, nil
+}
+
+func gcpClusterExist(service *container.Service, projectID, zone, clusterName string) bool {
+	clusters, err := getClusterList(service, projectID, zone)
+	if err != nil {
+		fmt.Printf("Failed to list clusters: %v", err)
+	}
+	if len(clusters) == 0 {
+		return false
+	}
+	if util.ContainsInStringArray(clusters, clusterName) {
+		return true
+	}
+	return false
 }

--- a/components/cli/pkg/util/utils.go
+++ b/components/cli/pkg/util/utils.go
@@ -954,3 +954,12 @@ func GetCurrentPath() (string, error) {
 	}
 	return dir, nil
 }
+
+func ContainsInStringArray(array []string, item string) bool {
+	for _, element := range array {
+		if element == item {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -14,7 +14,7 @@ cellery build <BAL_FILE_NAME> -t <ORGANIZATION_NAME>/<IMAGE_NAME>:<VERSION>
 ``` 
 Example : 
 ```
-cellery build my-project.bal -t wso2/my-cell:1.0.0
+cellery build my-project.bal wso2/my-cell:1.0.0
 ```
 
 ### Run

--- a/samples/employee-portal/README.md
+++ b/samples/employee-portal/README.md
@@ -28,7 +28,7 @@ four microservices deployed across three different cells based on their responsi
 2. Go into the stock directory inside cellery directory, and build the Stocks Cell with `cellery build` command. Then 
 run the cell in the cellery mesh by executing `cellery run` command as shown below.
 ```
-$ cellery build stocks.bal -t myorg/stock:1.0.0
+$ cellery build stocks.bal myorg/stock:1.0.0
 Building Stock Cell ...
 
 ✔ Building image myorg/stock:1.0.0
@@ -61,7 +61,7 @@ Execute the following command to list running cells:
 mentioned commands.
 ```
 $ cd employee
-$ cellery build employee.bal -t myorg/employee:1.0.0
+$ cellery build employee.bal myorg/employee:1.0.0
 Building Employee Cell ...
 
 ✔ Building image myorg/employee:1.0.0
@@ -94,7 +94,7 @@ Execute the following command to list running cells:
 specifies the names of the other cells which hr app depends on. Execute the commands provided below to build and runt the HR cells.
 ```
 $ cd hr
-$ cellery build hr.bal -t myorg/hr:1.0.0
+$ cellery build hr.bal myorg/hr:1.0.0
 Building HR Cell ...
 Warning: Value is empty for environment variable "employeegw_url"
 Warning: Value is empty for environment variable "stockgw_url”

--- a/samples/pet-service/README.md
+++ b/samples/pet-service/README.md
@@ -11,8 +11,8 @@ The component interaction diagram of the application is shown below.
 ## Deploying the sample
 1. Run the following command from the `sdk/samples/pet-service` directory:
     ```
-    $ cellery build pet-cell.bal -t pet-org/pet-service:1.0.0
-    cellery build petCell.bal -t pet-org/pet-service:1.0.0
+    $ cellery build pet-cell.bal pet-org/pet-service:1.0.0
+    cellery build petCell.bal pet-org/pet-service:1.0.0
     Building Pet Service Cell ...
     
     ✔ Building image pet-org/pet-service:1.0.0


### PR DESCRIPTION
1. In the cellery setup an option was created to delete an existing gcp cluster and delete. This will remove all the infrastructure related to the cluster (sql instance, nfs file store, storage bucket). Therefore the user will not have to manually delete them everytime.
2.Updated docs after "-t" flag was removed from cellery build command. 