### PR TITLE
Remove documentation links in macOS installer conclusion page

### DIFF
--- a/installers/macOS-x64/darwin/Resources/conclusion.html
+++ b/installers/macOS-x64/darwin/Resources/conclusion.html
@@ -15,7 +15,7 @@
                 <p style="color: #020202; font-size: 11px;">Run the following command for Cellery help:</p>
                 <code style="color: #c6a72b; font-size: 11px;">&nbsp; $ <span style="color: #abb0b0">cellery -h</span></code>
         </div>
-        <div style="font-family: Helvetica; padding-left: 10px;" align="left">
+        <!-- <div style="font-family: Helvetica; padding-left: 10px;" align="left">
             <br/>
             <h5>Resources</h5>
                 <p style="color: #020202; font-size: 11px;">Go through following links for additional information.</p>
@@ -23,7 +23,7 @@
                     <li><a href=" " style="font-size: 11px;">Quick Start Guide</a></li>
                     <li><a href=" " style="font-size: 11px;">Documentation</a></li>
                 </ul>
-        </div>
+        </div> -->
         <div style="font-family: Helvetica; padding-left: 10px;" align="left">
             <br/>
             <h5>Uninstall Cellery</h5>


### PR DESCRIPTION
## Purpose
> Comment un-used documentation links in conclusion page of the macOS installer until the documentation pages are ready. 

## Goals
> Remove un-used links in installers.

## Approach
> Comment out the documentation link section.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> macOS Sierra - 10.12.6, Ballerina - 0.990.3
 
## Learning
> N/A