### PR TITLE
Add aliases to the commands

### DIFF
--- a/components/cli/cmd/cellery/describe.go
+++ b/components/cli/cmd/cellery/describe.go
@@ -32,6 +32,7 @@ func newDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <instance-name|cell-image-name>",
 		Short: "Describes a cell image",
+		Aliases: []string{"desc"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			err := cobra.ExactArgs(1)(cmd, args)
 			if err != nil {

--- a/components/cli/cmd/cellery/extract_resources.go
+++ b/components/cli/cmd/cellery/extract_resources.go
@@ -34,6 +34,7 @@ func newExtractResourcesCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "extract-resources <organization>/<cell-image>:<version> <output-directory>",
 		Short: "Extract the resource files of a pulled image to the provided location",
+		Aliases: []string{"exctr"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			err := cobra.ExactArgs(1)(cmd, args)
 			if err != nil {

--- a/components/cli/cmd/cellery/inspect.go
+++ b/components/cli/cmd/cellery/inspect.go
@@ -32,6 +32,7 @@ func newInspectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inspect <organization>/<cell-image>:<version>",
 		Short: "List the files in the cell image",
+		Aliases: []string{"insp"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			err := cobra.ExactArgs(1)(cmd, args)
 			if err != nil {

--- a/components/cli/cmd/cellery/list_Instances.go
+++ b/components/cli/cmd/cellery/list_Instances.go
@@ -28,6 +28,7 @@ func newListInstancesCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "instances",
 		Short: "List all running cells",
+		Aliases: []string{"instance", "inst"},
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			commands.RunListInstances()

--- a/components/cli/cmd/cellery/list_components.go
+++ b/components/cli/cmd/cellery/list_components.go
@@ -32,6 +32,7 @@ func newListComponentsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "components <instance-name|cell-image-name>",
 		Short: "List the components which the cell encapsulates",
+		Aliases: []string{"component", "comp"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			err := cobra.ExactArgs(1)(cmd, args)
 			if err != nil {

--- a/components/cli/cmd/cellery/list_images.go
+++ b/components/cli/cmd/cellery/list_images.go
@@ -28,6 +28,7 @@ func newListImagesCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "images",
 		Short: "List cell images",
+		Aliases: []string{"image", "img"},
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {

--- a/components/cli/cmd/cellery/list_ingresses.go
+++ b/components/cli/cmd/cellery/list_ingresses.go
@@ -32,6 +32,7 @@ import (
 func newListIngressesCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ingresses <instance-name|cell-image-name>",
+		Aliases: []string{"ingress", "ing"},
 		Short: "List the exposed APIs of a cell instance",
 		Args: func(cmd *cobra.Command, args []string) error {
 			err := cobra.ExactArgs(1)(cmd, args)

--- a/components/cli/cmd/cellery/terminate.go
+++ b/components/cli/cmd/cellery/terminate.go
@@ -32,6 +32,7 @@ func newTerminateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "terminate <instance-name>",
 		Short: "Terminate a running cell instance",
+		Aliases: []string{"term"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			err := cobra.ExactArgs(1)(cmd, args)
 			if err != nil {

--- a/components/cli/cmd/cellery/version.go
+++ b/components/cli/cmd/cellery/version.go
@@ -28,6 +28,7 @@ func newVersionCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Get cellery runtime version",
+		Aliases: []string{"v", "ver"},
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			commands.RunVersion()


### PR DESCRIPTION
## Purpose
To add more usability for the CLI commands included alias for few commands such as list commands to work with both plural and singular resource names, etc. 