### PR TITLE
Implement CLI run with dependencies

### DIFF
--- a/components/cli/cmd/cellery/describe.go
+++ b/components/cli/cmd/cellery/describe.go
@@ -30,8 +30,8 @@ import (
 
 func newDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe <instance-name|cell-image-name>",
-		Short: "Describes a cell image",
+		Use:     "describe <instance-name|cell-image-name>",
+		Short:   "Describes a cell image",
 		Aliases: []string{"desc"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			err := cobra.ExactArgs(1)(cmd, args)

--- a/components/cli/cmd/cellery/extract_resources.go
+++ b/components/cli/cmd/cellery/extract_resources.go
@@ -32,8 +32,8 @@ import (
 func newExtractResourcesCommand() *cobra.Command {
 	var outputPath string
 	cmd := &cobra.Command{
-		Use:   "extract-resources <organization>/<cell-image>:<version> <output-directory>",
-		Short: "Extract the resource files of a pulled image to the provided location",
+		Use:     "extract-resources <organization>/<cell-image>:<version> <output-directory>",
+		Short:   "Extract the resource files of a pulled image to the provided location",
 		Aliases: []string{"exctr"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			err := cobra.ExactArgs(1)(cmd, args)

--- a/components/cli/cmd/cellery/inspect.go
+++ b/components/cli/cmd/cellery/inspect.go
@@ -30,8 +30,8 @@ import (
 // newListFilesCommand creates a command which can be invoked to list the files (directory structure) of a cell images.
 func newInspectCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "inspect <organization>/<cell-image>:<version>",
-		Short: "List the files in the cell image",
+		Use:     "inspect <organization>/<cell-image>:<version>",
+		Short:   "List the files in the cell image",
 		Aliases: []string{"insp"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			err := cobra.ExactArgs(1)(cmd, args)

--- a/components/cli/cmd/cellery/list_Instances.go
+++ b/components/cli/cmd/cellery/list_Instances.go
@@ -26,10 +26,10 @@ import (
 
 func newListInstancesCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "instances",
-		Short: "List all running cells",
+		Use:     "instances",
+		Short:   "List all running cells",
 		Aliases: []string{"instance", "inst"},
-		Args:  cobra.NoArgs,
+		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			commands.RunListInstances()
 		},

--- a/components/cli/cmd/cellery/list_components.go
+++ b/components/cli/cmd/cellery/list_components.go
@@ -30,8 +30,8 @@ import (
 
 func newListComponentsCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "components <instance-name|cell-image-name>",
-		Short: "List the components which the cell encapsulates",
+		Use:     "components <instance-name|cell-image-name>",
+		Short:   "List the components which the cell encapsulates",
 		Aliases: []string{"component", "comp"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			err := cobra.ExactArgs(1)(cmd, args)

--- a/components/cli/cmd/cellery/list_images.go
+++ b/components/cli/cmd/cellery/list_images.go
@@ -26,10 +26,10 @@ import (
 
 func newListImagesCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "images",
-		Short: "List cell images",
+		Use:     "images",
+		Short:   "List cell images",
 		Aliases: []string{"image", "img"},
-		Args:  cobra.NoArgs,
+		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				commands.RunImage()

--- a/components/cli/cmd/cellery/list_ingresses.go
+++ b/components/cli/cmd/cellery/list_ingresses.go
@@ -31,9 +31,9 @@ import (
 // newApisCommand creates a cobra command which can be invoked to get the APIs exposed by a cell
 func newListIngressesCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ingresses <instance-name|cell-image-name>",
+		Use:     "ingresses <instance-name|cell-image-name>",
 		Aliases: []string{"ingress", "ing"},
-		Short: "List the exposed APIs of a cell instance",
+		Short:   "List the exposed APIs of a cell instance",
 		Args: func(cmd *cobra.Command, args []string) error {
 			err := cobra.ExactArgs(1)(cmd, args)
 			if err != nil {

--- a/components/cli/cmd/cellery/run.go
+++ b/components/cli/cmd/cellery/run.go
@@ -31,7 +31,9 @@ import (
 
 func newRunCommand() *cobra.Command {
 	var name string
-	var dependencies []string
+	var withDependencies bool
+	var shareAllInstances bool
+	var dependencyLinks []string
 	cmd := &cobra.Command{
 		Use:   "run [<registry>/]<organization>/<cell-image>:<version>",
 		Short: "Use a cell image to create a running instance",
@@ -50,17 +52,31 @@ func newRunCommand() *cobra.Command {
 					return fmt.Errorf("expects a valid cell name, received %s", args[0])
 				}
 			}
+			for _, dependencyLink := range dependencyLinks {
+				isMatch, err := regexp.MatchString("^"+constants.DEPENDENCY_LINK_PATTERN+"$", dependencyLink)
+				if err != nil || !isMatch {
+					return fmt.Errorf("expects dependency links in the format "+
+						"[<parent-intanceinstance>.]<alias>:<dependent-instance>, received %s", dependencyLink)
+				}
+			}
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			commands.RunRun(args[0], name, dependencies)
+			commands.RunRun(args[0], name, withDependencies, shareAllInstances, dependencyLinks)
 		},
-		Example: "  cellery run cellery-samples/employee:1.0.0 -n employee\n" +
-			"  cellery run registry.foo.io/cellery-samples/employee:1.0.0 -n employee -l instance1 -l instance2 \n" +
-			"  cellery run cellery-samples/employee:1.0.0 -l instance1 -l instance2",
+		Example: "  cellery run cellery-samples/hr:1.0.0 -n hr-inst\n" +
+			"  cellery run registry.foo.io/cellery-samples/hr:1.0.0 -n hr-inst -l employee:employee-inst " +
+			"-l stock:stock-inst \n" +
+			"  cellery run cellery-samples/employee:1.0.0 -l employee-inst.people-hr:people-hr-inst\n" +
+			"  cellery run cellery-samples/employee:1.0.0 --share-instances " +
+			"-l employee-inst.people-hr:people-hr-inst",
 	}
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Name of the cell instance")
-	cmd.Flags().StringArrayVarP(&dependencies, "link", "l", nil,
-		"Dependency instance names")
+	cmd.Flags().BoolVarP(&withDependencies, "with-dependencies", "d", false,
+		"Start all the dependencies of this Cell Image in order")
+	cmd.Flags().BoolVarP(&shareAllInstances, "share-instances", "s", false,
+		"Share all instances among equivalent Cell Instances")
+	cmd.Flags().StringArrayVarP(&dependencyLinks, "link", "l", nil,
+		"Link an instance with a dependency alias")
 	return cmd
 }

--- a/components/cli/cmd/cellery/run.go
+++ b/components/cli/cmd/cellery/run.go
@@ -31,7 +31,7 @@ import (
 
 func newRunCommand() *cobra.Command {
 	var name string
-	var withDependencies bool
+	var startDependencies bool
 	var shareAllInstances bool
 	var dependencyLinks []string
 	cmd := &cobra.Command{
@@ -62,7 +62,7 @@ func newRunCommand() *cobra.Command {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			commands.RunRun(args[0], name, withDependencies, shareAllInstances, dependencyLinks)
+			commands.RunRun(args[0], name, startDependencies, shareAllInstances, dependencyLinks)
 		},
 		Example: "  cellery run cellery-samples/hr:1.0.0 -n hr-inst\n" +
 			"  cellery run registry.foo.io/cellery-samples/hr:1.0.0 -n hr-inst -l employee:employee-inst " +
@@ -72,7 +72,7 @@ func newRunCommand() *cobra.Command {
 			"-l employee-inst.people-hr:people-hr-inst",
 	}
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Name of the cell instance")
-	cmd.Flags().BoolVarP(&withDependencies, "with-dependencies", "d", false,
+	cmd.Flags().BoolVarP(&startDependencies, "start-dependencies", "d", false,
 		"Start all the dependencies of this Cell Image in order")
 	cmd.Flags().BoolVarP(&shareAllInstances, "share-instances", "s", false,
 		"Share all instances among equivalent Cell Instances")

--- a/components/cli/cmd/cellery/terminate.go
+++ b/components/cli/cmd/cellery/terminate.go
@@ -30,8 +30,8 @@ import (
 
 func newTerminateCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "terminate <instance-name>",
-		Short: "Terminate a running cell instance",
+		Use:     "terminate <instance-name>",
+		Short:   "Terminate a running cell instance",
 		Aliases: []string{"term"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			err := cobra.ExactArgs(1)(cmd, args)

--- a/components/cli/cmd/cellery/version.go
+++ b/components/cli/cmd/cellery/version.go
@@ -26,10 +26,10 @@ import (
 
 func newVersionCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "Get cellery runtime version",
+		Use:     "version",
+		Short:   "Get cellery runtime version",
 		Aliases: []string{"v", "ver"},
-		Args:  cobra.NoArgs,
+		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			commands.RunVersion()
 		},

--- a/components/cli/pkg/commands/build.go
+++ b/components/cli/pkg/commands/build.go
@@ -266,6 +266,9 @@ func generateMetaData(cellImage *util.CellImage, targetDir string) {
 			// Reading the dependency's metadata
 			metadataJsonContent, err := ioutil.ReadFile(
 				filepath.Join(tempPath, "artifacts", "cellery", "metadata.json"))
+			if err != nil {
+				util.ExitWithErrorMessage(errorMessage, err)
+			}
 			dependencyMetadata := &util.CellImageMetaData{}
 			err = json.Unmarshal(metadataJsonContent, dependencyMetadata)
 			if err != nil {

--- a/components/cli/pkg/commands/build.go
+++ b/components/cli/pkg/commands/build.go
@@ -246,6 +246,8 @@ func generateMetaData(cellImage *util.CellImage, targetDir string) {
 			dependencyExists, err := util.FileExists(cellImageZip)
 			if !dependencyExists {
 				RunPull(dependency, true)
+				fmt.Printf("\r\x1b[2K%s Pulling Cell Image %s/%s:%s\n", util.Green("\U00002714"),
+					dependencyCellImage.Organization, dependencyCellImage.ImageName, dependencyCellImage.ImageVersion)
 			}
 
 			// Create temp directory

--- a/components/cli/pkg/commands/pull.go
+++ b/components/cli/pkg/commands/pull.go
@@ -107,8 +107,8 @@ func RunPull(cellImage string, silent bool) {
 			}
 		}
 	}
-	util.PrintSuccessMessage(fmt.Sprintf("Successfully pulled cell image: %s", util.Bold(cellImage)))
 	if !silent {
+		util.PrintSuccessMessage(fmt.Sprintf("Successfully pulled cell image: %s", util.Bold(cellImage)))
 		util.PrintWhatsNextMessage("run the image", "cellery run "+cellImage)
 	}
 }
@@ -251,7 +251,6 @@ func pullImage(parsedCellImage *util.CellImage, username string, password string
 	if !silent {
 		spinner.Stop(true)
 	}
-	fmt.Print("\n\nImage Digest : " + util.Bold(cellImageDigest))
-
+	fmt.Printf("\nImage Digest : %s\n", util.Bold(cellImageDigest))
 	return nil
 }

--- a/components/cli/pkg/commands/push.go
+++ b/components/cli/pkg/commands/push.go
@@ -238,7 +238,6 @@ func pushImage(parsedCellImage *util.CellImage, username string, password string
 	}
 
 	spinner.Stop(true)
-	fmt.Print("\n\nImage Digest : " + util.Bold(cellImageDigest))
-
+	fmt.Printf("\nImage Digest : %s\n", util.Bold(cellImageDigest))
 	return nil
 }

--- a/components/cli/pkg/commands/run.go
+++ b/components/cli/pkg/commands/run.go
@@ -642,7 +642,7 @@ func startDependencyTree(registry string, tree *dependencyTreeNode, spinner *uti
 					}
 					dependencyNode.IsRunning = true
 					fmt.Printf("\r\x1b[2K%s Starting instance %s\n", util.Green("\U00002714"),
-						dependency.Instance)
+						dependencyNode.Instance)
 
 					err = os.RemoveAll(imageDir)
 					if err != nil {

--- a/components/cli/pkg/commands/run.go
+++ b/components/cli/pkg/commands/run.go
@@ -20,68 +20,575 @@ package commands
 
 import (
 	"bufio"
-	"bytes"
+	"crypto/rand"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
+
+	"github.com/olekukonko/tablewriter"
 
 	"github.com/cellery-io/sdk/components/cli/pkg/constants"
 	"github.com/cellery-io/sdk/components/cli/pkg/util"
 )
 
-func RunRun(cellImageTag string, instanceName string, dependencies []string) {
+func RunRun(cellImageTag string, instanceName string, withDependencies bool, shareDependencies bool,
+	dependencyLinks []string) {
 	parsedCellImage, err := util.ParseImageTag(cellImageTag)
 	if err != nil {
 		util.ExitWithErrorMessage("Error occurred while parsing cell image", err)
 	}
 
-	repoLocation := filepath.Join(util.UserHomeDir(), constants.CELLERY_HOME, "repo", parsedCellImage.Organization,
-		parsedCellImage.ImageName, parsedCellImage.ImageVersion)
-	fmt.Printf("Running cell image: %s\n", util.Bold(cellImageTag))
-	zipLocation := filepath.Join(repoLocation, parsedCellImage.ImageName+constants.CELL_IMAGE_EXT)
+	imageDir, err := extractImage(parsedCellImage)
+	if err != nil {
+		util.ExitWithErrorMessage("Error occurred while extracting image", err)
+	}
+	defer func() {
+		err = os.RemoveAll(imageDir)
+		if err != nil {
+			util.ExitWithErrorMessage("Error occurred while cleaning up", err)
+		}
+	}()
 
-	if _, err := os.Stat(zipLocation); os.IsNotExist(err) {
+	// Reading Cell Image metadata
+	metadataFileContent, err := ioutil.ReadFile(filepath.Join(imageDir, constants.ZIP_ARTIFACTS, "cellery",
+		"metadata.json"))
+	if err != nil {
+		util.ExitWithErrorMessage("Error occurred while reading Cell Image metadata", err)
+	}
+	cellImageMetadata := &util.CellImageMetaData{}
+	err = json.Unmarshal(metadataFileContent, cellImageMetadata)
+	if err != nil {
+		util.ExitWithErrorMessage("Error occurred while reading Cell Image metadata", err)
+	}
+
+	if instanceName == "" {
+		// Setting a unique instance name since it is not provided
+		instanceName, err = generateRandomInstanceName(cellImageMetadata)
+		if err != nil {
+			util.ExitWithErrorMessage("Error occurred while preparing", err)
+		}
+	}
+	fmt.Printf("\n%s: %s\n", util.Bold("Main Instance"), instanceName)
+
+	// Parsing the dependency links list
+	var parsedDependencyLinks []*dependencyAliasLink
+	for _, link := range dependencyLinks {
+		var dependencyLink *dependencyAliasLink
+		linkSplit := strings.Split(link, ":")
+		if strings.Contains(linkSplit[0], ".") {
+			instanceSplit := strings.Split(linkSplit[0], ".")
+			dependencyLink = &dependencyAliasLink{
+				Instance:           instanceSplit[0],
+				DependencyAlias:    instanceSplit[1],
+				DependencyInstance: linkSplit[1],
+			}
+		} else {
+			dependencyLink = &dependencyAliasLink{
+				DependencyAlias:    linkSplit[0],
+				DependencyInstance: linkSplit[1],
+			}
+		}
+		dependencyLink.IsRunning = isAvailableInRuntime(dependencyLink.DependencyInstance)
+		parsedDependencyLinks = append(parsedDependencyLinks, dependencyLink)
+	}
+	validateDependencyLinks(instanceName, cellImageMetadata, parsedDependencyLinks)
+
+	var mainNode *dependencyTreeNode
+	if withDependencies {
+		dependencyTree := generateDependencyTree(instanceName, cellImageMetadata, parsedDependencyLinks,
+			shareDependencies)
+		validateDependencyTree(dependencyTree)
+		confirmDependencyTree(dependencyTree)
+		startDependencyTree(parsedCellImage.Registry, dependencyTree)
+		mainNode = dependencyTree
+	} else {
+		immediateDependencies := map[string]*dependencyTreeNode{}
+		// Check if the provided links are immediate dependencies of the root Cell
+		for _, link := range parsedDependencyLinks {
+			if !link.IsRunning {
+				util.ExitWithErrorMessage("Invalid link",
+					fmt.Errorf("all the instances when running without depedencies should be "+
+						"running in the runtime, instance %s not available in the runtime", link.DependencyInstance))
+			} else if link.Instance == "" || link.Instance == instanceName {
+				if _, hasKey := cellImageMetadata.Dependencies[link.DependencyAlias]; hasKey {
+					immediateDependencies[link.DependencyAlias] = &dependencyTreeNode{
+						Instance:  link.DependencyInstance,
+						MetaData:  cellImageMetadata.Dependencies[link.DependencyAlias],
+						IsShared:  false,
+						IsRunning: link.IsRunning,
+					}
+				} else {
+					var allowedAliases []string
+					for alias := range cellImageMetadata.Dependencies {
+						allowedAliases = append(allowedAliases, alias)
+					}
+					util.ExitWithErrorMessage("Invalid links",
+						fmt.Errorf("only aliases of the main Cell instance %s: [%s] are allowed when running "+
+							"without starting dependencies, received %s", instanceName,
+							strings.Join(allowedAliases, ", "), link.DependencyAlias))
+				}
+			} else {
+				util.ExitWithErrorMessage("Invalid links",
+					fmt.Errorf("only the main Cell instance %s is allowed when running "+
+						"without starting dependencies, received unknown instance %s", instanceName, link.Instance))
+			}
+		}
+
+		// Check if instances are provided for all the dependencies of the root Cell
+		for alias := range cellImageMetadata.Dependencies {
+			isLinkProvided := false
+			for _, link := range parsedDependencyLinks {
+				if link.DependencyAlias == alias {
+					isLinkProvided = true
+					break
+				}
+			}
+			if !isLinkProvided {
+				util.ExitWithErrorMessage("Links for all the dependencies not found",
+					fmt.Errorf("required link for alias %s in instance %s not found", alias, instanceName))
+			}
+
+		}
+		mainNode = &dependencyTreeNode{
+			Instance:     instanceName,
+			MetaData:     cellImageMetadata,
+			IsRunning:    false,
+			IsShared:     false,
+			Dependencies: immediateDependencies,
+		}
+		validateDependencyTree(mainNode)
+		confirmDependencyTree(mainNode)
+	}
+
+	startCellInstance(imageDir, instanceName, mainNode)
+
+	util.PrintSuccessMessage(fmt.Sprintf("Successfully deployed cell image: %s", util.Bold(cellImageTag)))
+	util.PrintWhatsNextMessage("list running cells", "cellery list instances")
+}
+
+// validateDependencyTree validates the dependency tree of the root instance
+func validateDependencyLinks(rootInstance string, rootMetaData *util.CellImageMetaData,
+	dependencyLinks []*dependencyAliasLink) {
+	// Validating the links provided by the user
+	for _, link := range dependencyLinks {
+		if link.Instance == "" {
+			// This checks for duplicate aliases without parent instance and whether their Cell Images match.
+			// If the duplicate aliases have matching Cell Images, then they can share the instance.
+			// However, if duplicate aliases are present without parent instances and referring to different
+			// Cell Images, the links should be more specific using parent instance
+			var validateSubtree func(metadata *util.CellImageMetaData)
+			var cellImage *util.CellImage
+			validateSubtree = func(metadata *util.CellImageMetaData) {
+				for alias, dependencyMetadata := range metadata.Dependencies {
+					if alias == link.DependencyAlias {
+						if cellImage == nil {
+							// This is the first time the alias was found in the dependency tree.
+							// (Since the Cell Image was not set)
+							cellImage = &util.CellImage{
+								Organization: dependencyMetadata.Organization,
+								ImageName:    dependencyMetadata.Name,
+								ImageVersion: dependencyMetadata.Version,
+							}
+						} else {
+							// Check if the provided alias which is duplicated in the dependency tree is the same image
+							if cellImage.Organization != dependencyMetadata.Organization ||
+								cellImage.ImageName != dependencyMetadata.Name ||
+								cellImage.ImageVersion != dependencyMetadata.Version {
+								util.ExitWithErrorMessage("Invalid dependency links",
+									fmt.Errorf("duplicated alias %s in dependency tree, referes to different "+
+										"images %s/%s:%s and %s/%s:%s, provided aliases which are duplicated in the "+
+										"depedencies should be more specific using parent instance", alias,
+										cellImage.Organization, cellImage.ImageName, cellImage.ImageVersion,
+										dependencyMetadata.Organization, dependencyMetadata.Name,
+										dependencyMetadata.Version))
+							} else {
+								// Since the Cell Image is the same in both aliases the instance will be reused
+								fmt.Printf("%s Using a shared instance %s for duplicated alias %s\n",
+									util.YellowBold("\U000026A0"), util.Bold(link.DependencyInstance),
+									util.Bold(link.DependencyAlias))
+							}
+						}
+					}
+					validateSubtree(dependencyMetadata)
+				}
+			}
+			validateSubtree(rootMetaData)
+		} else {
+			// If the link has a parent instance, this checks if the parent instance had been provided by the user
+			// All used parent instances should be specified beforehand as the instance of another alias
+			var isLinkParentInstanceProvided bool
+			if rootInstance == link.Instance {
+				isLinkParentInstanceProvided = true
+			} else {
+				// Checking if the parent instance in the link is provided as an instance of another alias
+				for _, userSpecifiedLink := range dependencyLinks {
+					if link.Instance == userSpecifiedLink.DependencyInstance {
+						isLinkParentInstanceProvided = true
+						break
+					}
+				}
+			}
+			if !isLinkParentInstanceProvided {
+				util.ExitWithErrorMessage("Error occurred while starting dependencies",
+					fmt.Errorf("all parent instances of the provided links should be explicitly given "+
+						"as an instance of another alias, instance %s not provided", link.Instance))
+			}
+		}
+	}
+}
+
+// generateDependencyOrder reads the metadata and generates a proper start up order for dependencies
+func generateDependencyTree(rootInstance string, rootMetaData *util.CellImageMetaData,
+	dependencyLinks []*dependencyAliasLink, shareDependencies bool) *dependencyTreeNode {
+	// aliasToTreeNodeMap is used to keep track of the already created user provided tree nodes.
+	// The key of the is the alias and the value is the tree node.
+	// The alias is prefixed by the instance only if the user specified the parent instance as well.
+	aliasToTreeNodeMap := map[string]*dependencyTreeNode{}
+
+	// generatedInstanceTreeNodes are used to keep track of the instances automatically generated
+	// These will be shared among the auto generated instances based on "shareDependencies" environment variable
+	var generatedInstanceTreeNodes []*dependencyTreeNode
+
+	// traverseDependencies traverses through the dependency tree and populates the startup order considering the
+	// relationship between dependencies
+	var traverseDependencies func(instance string, metaData *util.CellImageMetaData, treeNode *dependencyTreeNode)
+	traverseDependencies = func(instance string, metaData *util.CellImageMetaData, treeNode *dependencyTreeNode) {
+		for alias, dependencyMetaData := range metaData.Dependencies {
+			var dependencyNode *dependencyTreeNode
+
+			// Check if the dependency link is provided by the user
+			for _, link := range dependencyLinks {
+				if alias == link.DependencyAlias && (link.Instance == "" || link.Instance == instance) {
+					var aliasPrefix string
+					if link.Instance != "" {
+						aliasPrefix = link.Instance + "."
+					}
+					key := aliasPrefix + alias
+
+					if node, hasKey := aliasToTreeNodeMap[key]; hasKey {
+						dependencyNode = node
+						dependencyNode.IsShared = true
+					} else {
+						dependencyNode = &dependencyTreeNode{
+							Instance:     link.DependencyInstance,
+							MetaData:     dependencyMetaData,
+							Dependencies: map[string]*dependencyTreeNode{},
+							IsShared:     false,
+							IsRunning:    link.IsRunning,
+						}
+						aliasToTreeNodeMap[key] = dependencyNode
+					}
+					break
+				}
+			}
+
+			if dependencyNode == nil {
+				if shareDependencies {
+					// Check if an instance had been already allocated for this image
+					for _, existingNode := range generatedInstanceTreeNodes {
+						if existingNode.MetaData.Organization == dependencyMetaData.Organization &&
+							existingNode.MetaData.Name == dependencyMetaData.Name &&
+							existingNode.MetaData.Version == dependencyMetaData.Version {
+							dependencyNode = existingNode
+							existingNode.IsShared = true
+						}
+					}
+				}
+
+				if dependencyNode == nil {
+					dependencyInstance, err := generateRandomInstanceName(dependencyMetaData)
+					if err != nil {
+						util.ExitWithErrorMessage("Error occurred while starting dependencies", err)
+					}
+					dependencyNode = &dependencyTreeNode{
+						Instance:     dependencyInstance,
+						MetaData:     dependencyMetaData,
+						Dependencies: map[string]*dependencyTreeNode{},
+						IsShared:     false,
+						IsRunning:    false,
+					}
+					generatedInstanceTreeNodes = append(generatedInstanceTreeNodes, dependencyNode)
+				}
+			}
+
+			// Traversing the dependencies (Depth First Search for start up items)
+			treeNode.Dependencies[alias] = dependencyNode
+			traverseDependencies(dependencyNode.Instance, dependencyMetaData, dependencyNode)
+		}
+	}
+	dependencyTreeRoot := &dependencyTreeNode{
+		Instance:     rootInstance,
+		MetaData:     rootMetaData,
+		Dependencies: map[string]*dependencyTreeNode{},
+		IsShared:     false,
+		IsRunning:    false,
+	}
+	traverseDependencies(rootInstance, rootMetaData, dependencyTreeRoot)
+	return dependencyTreeRoot
+}
+
+// validateDependencyTree validates a generated dependency tree
+func validateDependencyTree(treeRoot *dependencyTreeNode) {
+	// Validate whether the Cell Image of all the specified instances match
+	instanceToMetadataMap := map[string]*util.CellImageMetaData{}
+	var validateDependencySubtreeOffline func(subTreeRoot *dependencyTreeNode)
+	validateDependencySubtreeOffline = func(subTreeRoot *dependencyTreeNode) {
+		for _, dependency := range subTreeRoot.Dependencies {
+			if metadata, hasKey := instanceToMetadataMap[dependency.Instance]; hasKey {
+				if metadata.Organization != dependency.MetaData.Organization ||
+					metadata.Name != dependency.MetaData.Name ||
+					metadata.Version != dependency.MetaData.Version {
+					util.ExitWithErrorMessage("Invalid instance linking",
+						fmt.Errorf("instance %s cannot be shared by different Cell Images %s/%s:%s and %s/%s:%s",
+							dependency.Instance,
+							dependency.MetaData.Organization, dependency.MetaData.Name, dependency.MetaData.Version,
+							metadata.Organization, metadata.Name, metadata.Version))
+				}
+			} else {
+				instanceToMetadataMap[dependency.Instance] = dependency.MetaData
+			}
+			validateDependencySubtreeOffline(dependency)
+		}
+	}
+	instanceToMetadataMap[treeRoot.Instance] = treeRoot.MetaData
+	validateDependencySubtreeOffline(treeRoot)
+
+	// Validating whether the instances running in the runtime match the linked image
+	// TODO : Add logic to call the runtime
+}
+
+// confirmDependencyTree confirms from the user whether the intended dependency tree had been resolved
+func confirmDependencyTree(tree *dependencyTreeNode) {
+	var dependencyData [][]string
+	var traversedInstances []string
+	var extractDependencyTreeData func(subTree *dependencyTreeNode)
+	extractDependencyTreeData = func(subTree *dependencyTreeNode) {
+		for _, dependency := range subTree.Dependencies {
+			// Traversing the dependency tree
+			if !dependency.IsRunning {
+				extractDependencyTreeData(dependency)
+			}
+
+			// Adding used instances table content
+			instanceAlreadyAdded := false
+			for _, instance := range traversedInstances {
+				if instance == dependency.Instance {
+					instanceAlreadyAdded = true
+					break
+				}
+			}
+			if !instanceAlreadyAdded {
+				var usedInstance string
+				if dependency.IsRunning {
+					usedInstance = "Available in Runtime"
+				} else {
+					usedInstance = "To be Created"
+				}
+				var sharedSymbol string
+				if dependency.IsShared {
+					sharedSymbol = "Shared"
+				} else {
+					sharedSymbol = " - "
+				}
+				dependencyData = append(dependencyData, []string{
+					dependency.Instance,
+					dependency.MetaData.Organization + "/" + dependency.MetaData.Name + ":" + dependency.MetaData.Version,
+					usedInstance,
+					sharedSymbol,
+				})
+				traversedInstances = append(traversedInstances, dependency.Instance)
+			}
+		}
+	}
+	extractDependencyTreeData(tree)
+	dependencyData = append(dependencyData, []string{
+		tree.Instance,
+		tree.MetaData.Organization + "/" + tree.MetaData.Name + ":" + tree.MetaData.Version,
+		"To be Created",
+		" - ",
+	})
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"INSTANCE NAME", "CELL IMAGE", "USED INSTANCE", "SHARED"})
+	table.SetBorders(tablewriter.Border{Left: false, Top: false, Right: false, Bottom: false})
+	table.SetAlignment(3)
+	table.SetRowSeparator("-")
+	table.SetCenterSeparator(" ")
+	table.SetColumnSeparator(" ")
+	table.SetHeaderColor(
+		tablewriter.Colors{tablewriter.Bold},
+		tablewriter.Colors{tablewriter.Bold},
+		tablewriter.Colors{tablewriter.Bold},
+		tablewriter.Colors{tablewriter.Bold})
+	table.SetColumnColor(
+		tablewriter.Colors{},
+		tablewriter.Colors{},
+		tablewriter.Colors{},
+		tablewriter.Colors{})
+	table.AppendBulk(dependencyData)
+	fmt.Printf("\n%s:\n\n", util.Bold("Instances to be Used"))
+	table.Render()
+
+	fmt.Printf("\n%s:\n\n %s\n", util.Bold("Dependency Tree to be Used"), util.Bold(tree.Instance))
+	var printDependencyTree func(subTree *dependencyTreeNode, nestingLevel int, ancestorBranchPrintRequirement []bool)
+	printDependencyTree = func(subTree *dependencyTreeNode, nestingLevel int, ancestorBranchPrintRequirement []bool) {
+		var index = 0
+		for alias, dependency := range subTree.Dependencies {
+			// Adding the dependency tree visualization content
+			for j := 0; j < nestingLevel; j++ {
+				if ancestorBranchPrintRequirement[j] {
+					fmt.Print("   │ ")
+				} else {
+					fmt.Print("     ")
+				}
+			}
+			if index == len(subTree.Dependencies)-1 {
+				fmt.Print("   └")
+			} else {
+				fmt.Print("   ├")
+			}
+			fmt.Printf("── %s: %s\n", util.Bold(alias), dependency.Instance)
+
+			// Traversing the dependency tree
+			if !dependency.IsRunning {
+				printDependencyTree(dependency, nestingLevel+1,
+					append(ancestorBranchPrintRequirement, index != len(subTree.Dependencies)-1))
+			}
+			index++
+		}
+	}
+	printDependencyTree(tree, 0, []bool{})
+	fmt.Println()
+
+	fmt.Printf("%s Do you wish to continue with starting above Cell instances (Y/n)? ", util.YellowBold("?"))
+	reader := bufio.NewReader(os.Stdin)
+	confirmation, err := reader.ReadString('\n')
+	if err != nil {
+		util.ExitWithErrorMessage("Error occurred while confirming the dependency tree", err)
+	}
+	if strings.ToLower(strings.TrimSpace(confirmation)) == "n" {
+		fmt.Printf("%s Running Cell aborted\n", util.Red("\U0000274C"))
+		os.Exit(0)
+	}
+	fmt.Println()
+}
+
+// startDependencyTree starts up the whole dependency tree except the root
+// This does not start the root of the dependency tree
+func startDependencyTree(registry string, tree *dependencyTreeNode) {
+	var wg sync.WaitGroup
+	wg.Add(len(tree.Dependencies))
+	for _, dependency := range tree.Dependencies {
+		if dependency.IsRunning {
+			wg.Done()
+		} else { // This level of checking is done to not start unwanted goroutines
+			go func(dependencyNode *dependencyTreeNode) {
+				defer wg.Done()
+				dependencyNode.Mux.Lock()
+				if !dependencyNode.IsRunning { // This level of checking is done to make sure the condition is met
+					startDependencyTree(registry, dependencyNode)
+					//cellImage := &util.CellImage{
+					//	Registry:     registry,
+					//	Organization: dependencyNode.MetaData.Organization,
+					//	ImageName:    dependencyNode.MetaData.Name,
+					//	ImageVersion: dependencyNode.MetaData.Version,
+					//}
+					//imageDir, err := extractImage(cellImage)
+					//if err != nil {
+					//	util.ExitWithErrorMessage("Error occurred while extracting image", err)
+					//}
+
+					startCellInstance("", dependencyNode.Instance, dependencyNode)
+					dependencyNode.IsRunning = true
+
+					//err = os.RemoveAll(imageDir)
+					//if err != nil {
+					//	util.ExitWithErrorMessage("Error occurred while cleaning up", err)
+					//}
+				}
+				dependencyNode.Mux.Unlock()
+			}(dependency)
+		}
+	}
+	wg.Wait()
+}
+
+// extractImage extracts the image into a temporary directory and returns the path.
+// Cleaning the path after finishing your work is your responsibility.
+func extractImage(cellImage *util.CellImage) (string, error) {
+	repoLocation := filepath.Join(util.UserHomeDir(), constants.CELLERY_HOME, "repo", cellImage.Organization,
+		cellImage.ImageName, cellImage.ImageVersion)
+	zipLocation := filepath.Join(repoLocation, cellImage.ImageName+constants.CELL_IMAGE_EXT)
+	cellImageTag := cellImage.Organization + "/" + cellImage.ImageName + ":" + cellImage.ImageVersion
+
+	// Pull image if not exist
+	imageExists, err := util.FileExists(zipLocation)
+	if err != nil {
+		util.ExitWithErrorMessage("Error occurred while extracting the Cell image", err)
+	}
+	if !imageExists {
 		fmt.Printf("\nUnable to find image %s locally.", cellImageTag)
 		fmt.Printf("\nPulling image: %s", cellImageTag)
 		RunPull(cellImageTag, true)
 	}
 
-	// Create tmp directory
-	tmpPath := filepath.Join(util.UserHomeDir(), constants.CELLERY_HOME, "tmp", parsedCellImage.ImageName)
-	err = util.CleanOrCreateDir(tmpPath)
+	// Unzipping image to a temporary location
+	tempPath, err := ioutil.TempDir("", "cellery-cell-image")
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-
-	err = util.Unzip(zipLocation, tmpPath)
-	if err != nil {
-		panic(err)
-	}
-
+	err = util.Unzip(zipLocation, tempPath)
 	if err != nil {
 		util.ExitWithErrorMessage("Error occurred while extracting cell image", err)
 	}
-	balFileName, err := util.GetSourceFileName(filepath.Join(tmpPath, constants.ZIP_BALLERINA_SOURCE))
+	return tempPath, nil
+}
+
+func isAvailableInRuntime(instance string) bool {
+	// TODO : Check if the instance is available in the runtime
+	return instance == "test-inst" || instance == "stock-inst" || instance == "employee-inst"
+}
+
+func startCellInstance(imageDir string, instanceName string, runningNode *dependencyTreeNode) {
+	// TODO : Remove this method and rename the below method to match this method
+	fmt.Println("Started " + instanceName)
+	time.Sleep(2 * time.Second)
+	fmt.Println("Running " + instanceName)
+}
+
+func startCellInstance1(imageDir string, instanceName string, runningNode *dependencyTreeNode) {
+	balFileName, err := util.GetSourceFileName(filepath.Join(imageDir, constants.ZIP_BALLERINA_SOURCE))
 	if err != nil {
 		util.ExitWithErrorMessage("Error occurred while extracting source file: ", err)
 	}
-	balFilePath := filepath.Join(tmpPath, constants.ZIP_BALLERINA_SOURCE, balFileName)
+	balFilePath := filepath.Join(imageDir, constants.ZIP_BALLERINA_SOURCE, balFileName)
+
 	containsRunFunction, err := util.RunMethodExists(balFilePath)
 	if err != nil {
 		util.ExitWithErrorMessage("Error occurred while checking for run function ", err)
 	}
 	if containsRunFunction {
-		// Ballerina run method should be executed.
-		if instanceName == "" {
-			//Instance name not provided setting default {cellImageName}
-			instanceName = parsedCellImage.ImageName
+		// Generating the first level dependency map
+		dependencies := map[string]string{}
+		for alias, dependency := range runningNode.Dependencies {
+			dependencies[alias] = dependency.Instance
+		}
+
+		// Calling the run function
+		dependenciesJson, err := json.Marshal(dependencies)
+		if err != nil {
+			util.ExitWithErrorMessage("Error occurred while starting Cell instance"+instanceName, err)
 		}
 		cmd := exec.Command("ballerina", "run", balFilePath+":run",
-			parsedCellImage.Organization+"/"+parsedCellImage.ImageName,
-			parsedCellImage.ImageVersion,
-			instanceName, generateBalCompatibleMap(dependencies))
+			runningNode.MetaData.Organization+"/"+runningNode.MetaData.Name, runningNode.MetaData.Version,
+			instanceName, string(dependenciesJson))
+		cmd.Env = append(cmd.Env, constants.CELLERY_IMAGE_DIR_ENV_VAR+"="+imageDir)
 		stdoutReader, _ := cmd.StdoutPipe()
 		stdoutScanner := bufio.NewScanner(stdoutReader)
 		go func() {
@@ -106,18 +613,19 @@ func RunRun(cellImageTag string, instanceName string, dependencies []string) {
 		}
 	}
 
-	// Update the instance name
-	kubeYamlDir := filepath.Join(tmpPath, constants.ZIP_ARTIFACTS, "cellery")
-	kubeYamlFile := filepath.Join(kubeYamlDir, parsedCellImage.ImageName+".yaml")
+	// Update the Cell instance name
+	celleryDir := filepath.Join(imageDir, constants.ZIP_ARTIFACTS, "cellery")
+	k8sYamlFile := filepath.Join(celleryDir, runningNode.MetaData.Name+".yaml")
 	if instanceName != "" {
-		//Cell instance name changed.
-		err = util.ReplaceInFile(kubeYamlFile, "name: "+parsedCellImage.ImageName, "name: "+instanceName, 1)
-	}
-	if err != nil {
-		util.ExitWithErrorMessage("Error in replacing cell instance name", err)
+		// Cell instance name changed.
+		err = util.ReplaceInFile(k8sYamlFile, "name: "+runningNode.MetaData.Name, "name: "+instanceName, 1)
+		if err != nil {
+			util.ExitWithErrorMessage("Error in replacing cell instance name", err)
+		}
 	}
 
-	cmd := exec.Command("kubectl", "apply", "-f", kubeYamlDir)
+	// Applying the yaml
+	cmd := exec.Command(constants.KUBECTL, constants.APPLY, "-f", celleryDir)
 	stdoutReader, _ := cmd.StdoutPipe()
 	stdoutScanner := bufio.NewScanner(stdoutReader)
 	go func() {
@@ -137,33 +645,39 @@ func RunRun(cellImageTag string, instanceName string, dependencies []string) {
 		util.ExitWithErrorMessage("Error in executing cell run", err)
 	}
 	err = cmd.Wait()
-	_ = os.RemoveAll(kubeYamlDir)
-	_ = os.RemoveAll(tmpPath)
-
 	if err != nil {
 		util.ExitWithErrorMessage("Error occurred while running cell image", err)
 	}
-
-	util.PrintSuccessMessage(fmt.Sprintf("Successfully deployed cell image: %s", util.Bold(cellImageTag)))
-	util.PrintWhatsNextMessage("list running cells", "cellery list instances")
 }
 
-func generateBalCompatibleMap(depArr []string) string {
-	var strBuffer bytes.Buffer
-	strBuffer.WriteString("\"{")
-	for index, element := range depArr {
-		if index > 0 {
-			strBuffer.WriteString(",")
-		}
-		depElements := strings.Split(element, ":")
-		strBuffer.WriteString("\"")
-		strBuffer.WriteString(depElements[0])
-		strBuffer.WriteString("\"")
-		strBuffer.WriteString(":")
-		strBuffer.WriteString("\"")
-		strBuffer.WriteString(depElements[1])
-		strBuffer.WriteString("\"")
+// newUUID generates a random UUID according to RFC 4122
+func generateRandomInstanceName(dependencyMetaData *util.CellImageMetaData) (string, error) {
+	u := make([]byte, 4)
+	_, err := rand.Read(u)
+	if err != nil {
+		return "", err
 	}
-	strBuffer.WriteString("}\"")
-	return strBuffer.String()
+	uuid := fmt.Sprintf("%x", u)
+
+	// Generating random instance name
+	return dependencyMetaData.Organization + "-" + dependencyMetaData.Name + "-" +
+		strings.Replace(dependencyMetaData.Version, ".", "-", -1) + "-" + uuid, nil
+}
+
+// dependencyAliasLink is used to store the link information provided by the user
+type dependencyAliasLink struct {
+	Instance           string
+	DependencyAlias    string
+	DependencyInstance string
+	IsRunning          bool
+}
+
+// dependencyTreeNode is used as a node of the dependency tree
+type dependencyTreeNode struct {
+	Mux          sync.Mutex
+	Instance     string
+	MetaData     *util.CellImageMetaData
+	Dependencies map[string]*dependencyTreeNode
+	IsShared     bool
+	IsRunning    bool
 }

--- a/components/cli/pkg/commands/run.go
+++ b/components/cli/pkg/commands/run.go
@@ -716,9 +716,14 @@ func startCellInstance(imageDir string, instanceName string, runningNode *depend
 	}
 	if containsRunFunction {
 		// Generating the first level dependency map
-		dependencies := map[string]string{}
+		dependencies := map[string]*dependencyInfo{}
 		for alias, dependency := range runningNode.Dependencies {
-			dependencies[alias] = dependency.Instance
+			dependencies[alias] = &dependencyInfo{
+				Organization: dependency.MetaData.Organization,
+				Name:         dependency.MetaData.Name,
+				Version:      dependency.MetaData.Version,
+				InstanceName: dependency.Instance,
+			}
 		}
 
 		// Calling the run function
@@ -849,4 +854,12 @@ type dependencyTreeNode struct {
 	Dependencies map[string]*dependencyTreeNode
 	IsShared     bool
 	IsRunning    bool
+}
+
+// dependencyInfo is used to pass the dependency information to Ballerina
+type dependencyInfo struct {
+	Organization string `json:"org"`
+	Name         string `json:"name"`
+	Version      string `json:"ver"`
+	InstanceName string `json:"instanceName"`
 }

--- a/components/cli/pkg/constants/const.go
+++ b/components/cli/pkg/constants/const.go
@@ -23,6 +23,7 @@ const CELLERY_ID_PATTERN = "[a-z0-9]+(-[a-z0-9]+)*"
 const IMAGE_VERSION_PATTERN = "[0-9]+\\.[0-9]+\\.[0-9]+"
 const CELL_IMAGE_PATTERN = CELLERY_ID_PATTERN + "\\/" + CELLERY_ID_PATTERN + ":" + IMAGE_VERSION_PATTERN
 const CELL_IMAGE_WITH_REGISTRY_PATTERN = "(" + DOMAIN_NAME_PATTERN + "\\/)?" + CELL_IMAGE_PATTERN
+const DEPENDENCY_LINK_PATTERN = "(" + CELLERY_ID_PATTERN + "\\.)?" + CELLERY_ID_PATTERN + ":" + CELLERY_ID_PATTERN
 
 const GROUP_NAME = "mesh.cellery.io"
 
@@ -117,3 +118,5 @@ const K8S_ARTIFACTS_PATH_MAC = "/Library/Cellery/artifacts"
 const K8S_ARTIFACTS_PATH_UBUNTU = "/usr/share/cellery/artifacts"
 
 const WSO2_APIM_HOST = "https://wso2-apim-gateway"
+
+const CELLERY_IMAGE_DIR_ENV_VAR = "CELLERY_IMAGE_DIR"

--- a/components/cli/pkg/util/utils.go
+++ b/components/cli/pkg/util/utils.go
@@ -39,8 +39,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/manifoldco/promptui"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -691,18 +689,18 @@ func (s *Spinner) Stop(isSuccess bool) {
 func (s *Spinner) spin() {
 	if s.isSpinning == true {
 		if s.action != s.previousAction {
-			var icon string
-			if s.error {
-				icon = Red("\U0000274C")
-			} else {
-				icon = Green("\U00002714")
+			if s.previousAction != "" {
+				var icon string
+				if s.error {
+					icon = Red("\U0000274C")
+				} else {
+					icon = Green("\U00002714")
+				}
+				fmt.Printf("\r\x1b[2K%s %s\n", icon, s.previousAction)
 			}
-			fmt.Printf("\r\x1b[2K%s %s\n", icon, s.previousAction)
 			s.previousAction = s.action
 		}
-		if s.action == "" {
-			s.isSpinning = false
-		} else {
+		if s.action != "" {
 			fmt.Printf("\r\x1b[2K\033[36m%s\033[m %s", s.core.Next(), s.action)
 		}
 	}

--- a/components/cli/pkg/util/utils.go
+++ b/components/cli/pkg/util/utils.go
@@ -47,6 +47,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/fatih/color"
+	"github.com/manifoldco/promptui"
 	"github.com/tj/go-spin"
 	"golang.org/x/crypto/ssh/terminal"
 
@@ -925,14 +926,17 @@ func GetSourceFileName(filePath string) (string, error) {
 	return "", errors.New("Ballerina source file not found in extracted location: " + filePath)
 }
 
+// RunMethodExists checks if the run method exists in ballerina file
 func RunMethodExists(sourceFile string) (bool, error) {
-	bytes, err := ioutil.ReadFile(sourceFile)
+	sourceFileBytes, err := ioutil.ReadFile(sourceFile)
 	if err != nil {
 		return false, err
 	}
-	content := string(bytes)
-	// //check whether s contains substring text
-	return regexp.MatchString(".*(public)\\s+(function)\\s+(run)\\s*\\(\\s*(string)\\s+.*\\s(string)\\s+.*\\s(string)\\s+.*", content)
+
+	// Check whether s contains substring text
+	return regexp.MatchString(
+		".*(public)\\s+(function)\\s+(run)\\s*\\(\\s*(string)\\s+.*\\s(string)\\s+.*\\s(string)\\s+.*",
+		string(sourceFileBytes))
 }
 
 func ReplaceInFile(srcFile, oldString, newString string, replaceCount int) error {

--- a/components/docs-view/src/App.js
+++ b/components/docs-view/src/App.js
@@ -37,7 +37,7 @@ const styles = {
         color: "#464646"
     },
     appBar: {
-        boxShadow : "none"
+        boxShadow: "none"
     }
 };
 

--- a/components/lang/src/main/java/io/cellery/CelleryConstants.java
+++ b/components/lang/src/main/java/io/cellery/CelleryConstants.java
@@ -17,8 +17,6 @@
  */
 package io.cellery;
 
-import java.io.File;
-
 /**
  * Collected constants of Cellery.
  */
@@ -49,10 +47,7 @@ public class CelleryConstants {
     public static final String DEFAULT_GATEWAY_PROTOCOL = "http";
     public static final int DEFAULT_GATEWAY_PORT = 80;
     public static final String DEFAULT_PARAMETER_VALUE = "";
-    public static final String CELLERY_HOME = System.getProperty("user.home") + File.separator +
-            ".cellery";
-    public static final String CELLERY_REPO_PATH = CELLERY_HOME + File.separator + "repo" + File.separator;
-    public static final String CELL_YAML_PATH = "artifacts" + File.separator + "cellery" + File.separator;
+    public static final String CELLERY_IMAGE_DIR_ENV_VAR = "CELLERY_IMAGE_DIR";
 
     public static final String ANNOTATION_CELL_IMAGE_ORG = "mesh.cellery.io/cell-image-org";
     public static final String ANNOTATION_CELL_IMAGE_NAME = "mesh.cellery.io/cell-image-name";

--- a/components/lang/src/main/java/io/cellery/impl/CreateInstance.java
+++ b/components/lang/src/main/java/io/cellery/impl/CreateInstance.java
@@ -39,8 +39,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static io.cellery.CelleryConstants.CELLERY_HOME;
-import static io.cellery.CelleryConstants.CELL_YAML_PATH;
+import static io.cellery.CelleryConstants.CELLERY_IMAGE_DIR_ENV_VAR;
 import static io.cellery.CelleryConstants.YAML;
 import static io.cellery.CelleryUtils.processParameters;
 import static io.cellery.CelleryUtils.toYaml;
@@ -66,7 +65,7 @@ public class CreateInstance extends BlockingNativeCallableUnit {
     public void execute(Context ctx) {
         String[] cellNameData = ctx.getStringArgument(0).split("/");
         String cellName = cellNameData[1];
-        String destinationPath = CELLERY_HOME + File.separator + "tmp" + File.separator + cellName + File.separator +
+        String destinationPath = System.getenv(CELLERY_IMAGE_DIR_ENV_VAR) + File.separator +
                 "artifacts" + File.separator + "cellery" + File.separator + cellName + YAML;
         Cell cell = getInstance(destinationPath);
         final BMap refArgument = (BMap) ctx.getNullableRefArgument(0);
@@ -101,7 +100,7 @@ public class CreateInstance extends BlockingNativeCallableUnit {
                     "pull/build the cell image ?");
         }
         if (cell == null) {
-            throw new BallerinaException("Unable to extract Cell Image yaml " + CELL_YAML_PATH);
+            throw new BallerinaException("Unable to extract Cell Image yaml " + destinationPath);
         }
         return cell;
     }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -32,15 +32,33 @@ cellery run wso2/my-cell:1.0.0 -n my-cell-name1
 ```
 
 ### Run linking to dependencies
-Use a cellery image to create a running instance specifying an instance name
+Use a cellery image to create a running instance specifying an instance name.
 Input the same instance name to establish the link between the running cell instance and another cell which depends on it.  
 Usage : 
 ```
-cellery run <ORGANIZATION_NAME>/<IMAGE_NAME>:<VERSION> -l <NAME-1>
+cellery run <ORGANIZATION_NAME>/<IMAGE_NAME>:<VERSION> -l <ALIAS>:<NAME-1>
 ```
 Example : 
 ```
-cellery run wso2/cell2:1.0.1 -n mycell-2 -l mycell-1
+cellery run wso2/cell2:1.0.1 -n mycell-2 -l cell-1:mycell-1
+```
+
+### Run with dependencies
+Use a cellery image to create a running instance specifying an instance name along with its dependencies. (The images will be pulled from the Registry if required)
+Input the same instance name to establish the link between the running cell instance and another cell which depends on it.
+Any unspecified (no links provided) can be shared (if the Cell Image is the same) by using the `--share-instances` flag.
+You will be prompted the confirm the instances and the dependency tree before starting the instances.
+Usage : 
+```
+cellery run <ORGANIZATION_NAME>/<IMAGE_NAME>:<VERSION> --with-dependencies
+cellery run <ORGANIZATION_NAME>/<IMAGE_NAME>:<VERSION> --with-dependencies --share-instances
+cellery run <ORGANIZATION_NAME>/<IMAGE_NAME>:<VERSION> --with-dependencies -l <PARENT-INSTANCE>.<ALIAS>:<NAME-1>
+```
+Example : 
+```
+cellery run wso2/cell2:1.0.1 -n mycell-2 -l cell-1:mycell-1
+cellery run wso2/cell2:1.0.1 -n mycell-2 --with-dependencies
+cellery run wso2/cell2:1.0.1 -n mycell-2 --with-dependencies --share-instances
 ```
 
 ### List instances


### PR DESCRIPTION
## Purpose
> Implement support starting a Cell instance along with its dependencies

## Goals
> Address part of #130 by allowing the user to easily run a Cell instance along with its dependencies as well as have the flexibility to specify parts of the dependency tree if required. Fix #156 by printing the instance name as well as other details.

## Approach
> Using --with-dependencies flag, the user can instruct the CLI to pull all the dependencies that he had not explicitly given. Using --link flag, the user can provide the instances that should be used for the dependency aliases. Using --share-dependencies flag, the user can instruct the CLI to share all the CLI generated instances (instances not specified by the user) if possible. Moreover, if an alias is duplicated for the same Cell Image, the CLI will share that instance.

## User stories
> As a user, I want to start a Cell instance along with its dependencies easily and have the flexibility to explicitly specify the instances in the dependency tree.

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> go1.11 linux/amd64

## Learning
> N/A