### PR TITLE
Remove release version pattern validation

### DIFF
--- a/installers/macOS-x64/build-macos-x64.sh
+++ b/installers/macOS-x64/build-macos-x64.sh
@@ -37,12 +37,12 @@ function printUsage() {
 if [[ "$1" == "-h" ||  "$1" == "--help" ]]; then
     printUsage
     exit 1
-elif [[ "$1" == [0-9].[0-9].[0-9] ]]; then
-    echo "Cellery Version : $1"
-else
-    echo "Please enter a valid version for cellery distribution"
+elif [ -z "$1"]; then
+    echo "Please enter the version of the Cellery distribution."
     printUsage
     exit 1
+else
+    echo "Cellery Version : $1"
 fi
 
 #Parameters


### PR DESCRIPTION
## Purpose
> Contains changes for removing release version input validation. The current script does not allow giving a commit hash as the installer version.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes