### PR TITLE
setting correct executable path for ballerin commands

### DIFF
--- a/components/cli/pkg/commands/build.go
+++ b/components/cli/pkg/commands/build.go
@@ -79,7 +79,12 @@ func RunBuild(tag string, fileName string) {
 		util.ExitWithErrorMessage("Error in generating cellery:CellImageName construct", err)
 	}
 	// Executing the build method in the cell file
-	cmd := exec.Command("ballerina", "run", constants.BALLERINA_PRINT_RETURN_FLAG, fileName+":build", string(iName))
+	moduleMgr := &util.BLangManager{}
+	exePath, err := moduleMgr.GetExecutablePath()
+	if err != nil {
+		util.ExitWithErrorMessage("Failed to get executable path", err)
+	}
+	cmd := exec.Command(exePath + "ballerina", "run", constants.BALLERINA_PRINT_RETURN_FLAG, fileName+":build", string(iName))
 	execError := ""
 	stderrReader, _ := cmd.StderrPipe()
 	stderrScanner := bufio.NewScanner(stderrReader)

--- a/components/cli/pkg/commands/run.go
+++ b/components/cli/pkg/commands/run.go
@@ -867,7 +867,12 @@ func startCellInstance(imageDir string, instanceName string, runningNode *depend
 		cmdArgs = append(cmdArgs, balFilePath+":run", string(iName), string(dependenciesJson))
 
 		// Calling the run function
-		cmd := exec.Command("ballerina", cmdArgs...)
+		moduleMgr := &util.BLangManager{}
+		exePath, err := moduleMgr.GetExecutablePath()
+		if err != nil {
+			util.ExitWithErrorMessage("Failed to get executable path", err)
+		}
+		cmd := exec.Command(exePath + "ballerina", cmdArgs...)
 		cmd.Env = os.Environ()
 		cmd.Env = append(cmd.Env, constants.CELLERY_IMAGE_DIR_ENV_VAR+"="+imageDir)
 		stdoutReader, _ := cmd.StdoutPipe()

--- a/components/cli/pkg/commands/version.go
+++ b/components/cli/pkg/commands/version.go
@@ -52,7 +52,12 @@ func RunVersion() {
 
 	// Printing Ballerina version information
 	_, _ = boldWhite.Println("\nBallerina:")
-	balVersionCmd := exec.Command("ballerina", "version")
+	moduleMgr := &util.BLangManager{}
+	exePath, err := moduleMgr.GetExecutablePath()
+	if err != nil {
+		util.ExitWithErrorMessage("Failed to get executable path", err)
+	}
+	balVersionCmd := exec.Command(exePath + "ballerina", "version")
 	balResult, err := balVersionCmd.Output()
 	if err != nil {
 		util.ExitWithErrorMessage("Ballerina not found",

--- a/components/cli/pkg/constants/const.go
+++ b/components/cli/pkg/constants/const.go
@@ -127,6 +127,7 @@ const COMPLETE = "Complete"
 
 const CELLERY_INSTALLATION_PATH_MAC = "/Library/Cellery"
 const CELLERY_INSTALLATION_PATH_UBUNTU = "/usr/share/cellery"
+const CELLERY_EXECUTABLE_PATH = "/runtime/executable/"
 
 const WSO2_APIM_HOST = "https://wso2-apim-gateway"
 

--- a/components/cli/pkg/util/lang.go
+++ b/components/cli/pkg/util/lang.go
@@ -20,14 +20,17 @@ package util
 
 import (
 	"bufio"
+	"github.com/cellery-io/sdk/components/cli/pkg/constants"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 type LangManager interface {
 	Init() error
+	GetExecutablePath() (string, error)
 }
 
 type BLangManager struct{}
@@ -59,4 +62,15 @@ func (langMgr *BLangManager) Init() error {
 		return err
 	}
 	return nil
+}
+
+func (langMgr *BLangManager) GetExecutablePath() (string, error) {
+	exePath := strings.TrimSuffix(CelleryInstallationDir(), "/") + constants.CELLERY_EXECUTABLE_PATH
+	if _, err := os.Stat(exePath); os.IsNotExist(err) {
+		return "", nil
+	} else if err != nil {
+		return "", err
+	}
+	log.Printf("Executable path: %sballerina", exePath)
+	return exePath, nil
 }

--- a/installers/macOS-x64/build-macos-x64.sh
+++ b/installers/macOS-x64/build-macos-x64.sh
@@ -172,8 +172,6 @@ copyBuildDirectory() {
 
     cp ../../components/lang/target/cellery-*.jar ${TARGET_DIRECTORY}/darwinpkg/Library/Cellery/runtime/${BALLERINA_RUNTIME}/bre/lib/
     cp -R ../../components/lang/target/generated-balo/repo/celleryio ${TARGET_DIRECTORY}/darwinpkg/Library/Cellery/repo
-    chmod -R 755 ${TARGET_DIRECTORY}/darwinpkg
-    chmod 0644 ${TARGET_DIRECTORY}/darwinpkg/Library/Cellery/repo/celleryio/cellery/*/cellery.zip
 
     mkdir -p ${TARGET_DIRECTORY}/${INSTALLATION_DIRECTORY}/darwinpkg/Library/Cellery/docs-view
     cp -R ../../components/docs-view/build/* ${TARGET_DIRECTORY}/${INSTALLATION_DIRECTORY}/darwinpkg/Library/Cellery/docs-view

--- a/installers/macOS-x64/darwin/scripts/postinstall
+++ b/installers/macOS-x64/darwin/scripts/postinstall
@@ -18,16 +18,22 @@
 # ----------------------------------------------------------------------------------
 #
 
-echo "Post installation process started"
-PRODUCT_HOME=/Library/Cellery/
+#echo "Post installation process started"
+PRODUCT_HOME=/Library/Cellery
+BALLERINA_RUNTIME="ballerina-0.990.3"
 
 # Change permissions in home directory
-echo "Change permissions in product home"
-cd $PRODUCT_HOME
+cd ${PRODUCT_HOME}
 chmod -R 755 .
+chmod 0644 repo/celleryio/cellery/*/cellery.zip
 [ -d /usr/local/bin ] || mkdir /usr/local/bin
+
+# create a symlink so that executable path can be used without version
+SYMLINK_DIR=${PRODUCT_HOME}/runtime/executable
+mkdir -p ${SYMLINK_DIR}
+ln -sf ${PRODUCT_HOME}/runtime/${BALLERINA_RUNTIME}/bin/ballerina ${SYMLINK_DIR}/ballerina
 
 # Add cellery shortcut to /usr/local/bin
 rm -f /usr/local/bin/cellery
-ln -s $PRODUCT_HOME/cellery /usr/local/bin/cellery
-echo "Post installation process finished"
+ln -s ${PRODUCT_HOME}/cellery /usr/local/bin/cellery
+#echo "Post installation process finished"

--- a/installers/ubuntu-x64/build-ubuntu-x64.sh
+++ b/installers/ubuntu-x64/build-ubuntu-x64.sh
@@ -153,8 +153,6 @@ copyBuildDirectories() {
     cp -R $RESOURCE_LOCATION/k8s-* ${TARGET_DIRECTORY}/${INSTALLATION_DIRECTORY}/usr/share/cellery
 
     cp -R ../../components/lang/target/generated-balo/repo/celleryio ${TARGET_DIRECTORY}/${INSTALLATION_DIRECTORY}/usr/share/cellery/repo
-    chmod -R 0755 ${TARGET_DIRECTORY}/${INSTALLATION_DIRECTORY}/usr/share/cellery/
-    chmod 0644 ${TARGET_DIRECTORY}/${INSTALLATION_DIRECTORY}/usr/share/cellery/repo/celleryio/cellery/*/cellery.zip
     cp ../../components/lang/target/cellery-*.jar ${TARGET_DIRECTORY}/${INSTALLATION_DIRECTORY}/usr/share/cellery/runtime/${BALLERINA_RUNTIME}/bre/lib/
     mkdir -p ${TARGET_DIRECTORY}/${INSTALLATION_DIRECTORY}/usr/local/bin
     cp ../../components/build/cellery ${TARGET_DIRECTORY}/${INSTALLATION_DIRECTORY}/usr/local/bin

--- a/installers/ubuntu-x64/resources/DEBIAN/postinst
+++ b/installers/ubuntu-x64/resources/DEBIAN/postinst
@@ -7,3 +7,16 @@ fi
 if [ "$1" = abort-upgrade ]; then
 	echo "Aborting the installation without upgrading."
 fi
+
+#echo "Post installation process started"
+PRODUCT_HOME=/usr/share/cellery
+BALLERINA_RUNTIME="ballerina-0.990.3"
+
+# create a symlink so that executable path can be used without version
+SYMLINK_DIR=${PRODUCT_HOME}/runtime/executable
+mkdir -p ${SYMLINK_DIR}
+ln -sf ${PRODUCT_HOME}/runtime/${BALLERINA_RUNTIME}/bin/ballerina ${SYMLINK_DIR}/ballerina
+
+chmod -R 0755 ${PRODUCT_HOME}
+chmod 0644 ${PRODUCT_HOME}/repo/celleryio/cellery/*/cellery.zip
+#echo "Post installation process finished"

--- a/installers/ubuntu-x64/resources/DEBIAN/postrm
+++ b/installers/ubuntu-x64/resources/DEBIAN/postrm
@@ -10,5 +10,6 @@ then
 	echo "Remove configuration files."
 	sudo rm /usr/local/bin/cellery
 fi
+sudo rm -rf /usr/share/cellery/
 
 


### PR DESCRIPTION
## Purpose
> Set the executable path to installed one by cellery, ignoring any other b7a installations which already exist. 