### PR TITLE
support non-interactive cellery run command

### DIFF
--- a/components/cli/cmd/cellery/run.go
+++ b/components/cli/cmd/cellery/run.go
@@ -33,6 +33,7 @@ func newRunCommand() *cobra.Command {
 	var name string
 	var startDependencies bool
 	var shareAllInstances bool
+	var assumeYes bool
 	var dependencyLinks []string
 	var envVars []string
 	cmd := &cobra.Command{
@@ -72,9 +73,12 @@ func newRunCommand() *cobra.Command {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			commands.RunRun(args[0], name, startDependencies, shareAllInstances, dependencyLinks, envVars)
+			commands.RunRun(args[0], name, startDependencies, shareAllInstances, dependencyLinks, envVars,
+				assumeYes)
 		},
 		Example: "  cellery run cellery-samples/hr:1.0.0 -n hr-inst\n" +
+			"  cellery run cellery-samples/hr:1.0.0 -n hr-inst -y\n" +
+			"  cellery run cellery-samples/hr:1.0.0 -n hr-inst --assume-yes\n" +
 			"  cellery run registry.foo.io/cellery-samples/hr:1.0.0 -n hr-inst -l employee:employee-inst " +
 			"-l stock:stock-inst \n" +
 			"  cellery run cellery-samples/employee:1.0.0 -l employee-inst.people-hr:people-hr-inst\n" +
@@ -82,6 +86,8 @@ func newRunCommand() *cobra.Command {
 			"-l employee-inst.people-hr:people-hr-inst",
 	}
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Name of the cell instance")
+	cmd.Flags().BoolVarP(&assumeYes, "assume-yes", "y", false,
+		"Flag to enable/disable prompting for confirmation before starting instance(s)")
 	cmd.Flags().BoolVarP(&startDependencies, "start-dependencies", "d", false,
 		"Start all the dependencies of this Cell Image in order")
 	cmd.Flags().BoolVarP(&shareAllInstances, "share-instances", "s", false,

--- a/components/cli/pkg/commands/run.go
+++ b/components/cli/pkg/commands/run.go
@@ -40,8 +40,8 @@ import (
 // RunRun starts Cell instance (along with dependency instances if specified by the user)
 // This also support linking instances to parts of the dependency tree
 // This command also strictly validates whether the requested Cell (and the dependencies are valid)
-func RunRun(cellImageTag string, instanceName string, startDependencies bool, shareDependencies bool,
-	dependencyLinks []string, envVars []string) {
+func RunRun(cellImageTag string, instanceName string, assumeYes bool, shareDependencies bool,
+	dependencyLinks []string, envVars []string, promptForConfirmation bool) {
 	spinner := util.StartNewSpinner("Extracting Cell Image " + util.Bold(cellImageTag))
 	parsedCellImage, err := util.ParseImageTag(cellImageTag)
 	if err != nil {
@@ -198,7 +198,7 @@ func RunRun(cellImageTag string, instanceName string, startDependencies bool, sh
 	}
 
 	var mainNode *dependencyTreeNode
-	if startDependencies {
+	if assumeYes {
 		spinner.SetNewAction("Generating dependency tree")
 		dependencyTree, err := generateDependencyTree(instanceName, cellImageMetadata, parsedDependencyLinks,
 			shareDependencies)
@@ -212,7 +212,7 @@ func RunRun(cellImageTag string, instanceName string, startDependencies bool, sh
 			util.ExitWithErrorMessage("Invalid instance linking", err)
 		}
 		spinner.SetNewAction("")
-		err = confirmDependencyTree(dependencyTree)
+		err = confirmDependencyTree(dependencyTree, promptForConfirmation)
 		if err != nil {
 			spinner.Stop(false)
 			util.ExitWithErrorMessage("Failed to confirm the dependency tree", err)
@@ -296,7 +296,7 @@ func RunRun(cellImageTag string, instanceName string, startDependencies bool, sh
 			util.ExitWithErrorMessage("Invalid instance linking", err)
 		}
 		spinner.SetNewAction("")
-		err = confirmDependencyTree(mainNode)
+		err = confirmDependencyTree(mainNode, promptForConfirmation)
 		if err != nil {
 			util.ExitWithErrorMessage("Failed to confirm the dependency tree", err)
 		}
@@ -593,7 +593,7 @@ func validateDependencyTree(treeRoot *dependencyTreeNode) error {
 }
 
 // confirmDependencyTree confirms from the user whether the intended dependency tree had been resolved
-func confirmDependencyTree(tree *dependencyTreeNode) error {
+func confirmDependencyTree(tree *dependencyTreeNode, assumeYes bool) error {
 	var dependencyData [][]string
 	var traversedInstances []string
 	// Preparing instances table data
@@ -704,14 +704,16 @@ func confirmDependencyTree(tree *dependencyTreeNode) error {
 	}
 	fmt.Println()
 
-	fmt.Printf("%s Do you wish to continue with starting above Cell instances (Y/n)? ", util.YellowBold("?"))
-	reader := bufio.NewReader(os.Stdin)
-	confirmation, err := reader.ReadString('\n')
-	if err != nil {
-		return err
-	}
-	if strings.ToLower(strings.TrimSpace(confirmation)) == "n" {
-		return fmt.Errorf("running Cell aborted")
+	if !assumeYes {
+		fmt.Printf("%s Do you wish to continue with starting above Cell instances (Y/n)? ", util.YellowBold("?"))
+		reader := bufio.NewReader(os.Stdin)
+		confirmation, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if strings.ToLower(strings.TrimSpace(confirmation)) == "n" {
+			return fmt.Errorf("running Cell aborted")
+		}
 	}
 	fmt.Println()
 	return nil


### PR DESCRIPTION
## Purpose
> By default cellery run will prompt for Y/n before starting instances. When you pass **-y** or **--assume-yes** to run command, the instances will be started immediately without waiting for confirmation. 