### PR TITLE
wait 5secs before applying istio demo yaml

### DIFF
--- a/components/cli/pkg/commands/setup_create_existing_cluster.go
+++ b/components/cli/pkg/commands/setup_create_existing_cluster.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
@@ -500,6 +501,8 @@ func executeControllerArtifacts(artifactPath, errorDeployingCelleryRuntime strin
 	// Istio
 	util.ExecuteCommand(exec.Command(constants.KUBECTL, constants.APPLY, constants.KUBECTL_FLAG,
 		artifactPath+"/k8s-artefacts/system/istio-crds.yaml"), errorDeployingCelleryRuntime)
+	// sleep for few seconds - this is to make sure that the CRDs are properly applied
+	time.Sleep(5 * time.Second)
 	// Install Istio
 	util.ExecuteCommand(exec.Command(constants.KUBECTL, constants.APPLY, constants.KUBECTL_FLAG,
 		artifactPath+"/k8s-artefacts/system/istio-demo-cellery.yaml"), errorDeployingCelleryRuntime)

--- a/components/cli/pkg/commands/setup_create_gcp.go
+++ b/components/cli/pkg/commands/setup_create_gcp.go
@@ -176,7 +176,7 @@ func configureBucketOnGcp(ctx context.Context, gcpSpinner *util.Spinner, gcpBuck
 		fmt.Printf("Error creating storage client: %v", err)
 	}
 	// Upload init file to S3 bucket
-	gcpSpinner.SetNewAction("Uploading init.sql file to dcp bucket")
+	gcpSpinner.SetNewAction("Uploading init.sql file to GCP bucket")
 	if err := uploadSqlFile(client, gcpBucketName, constants.INIT_SQL); err != nil {
 		gcpSpinner.Stop(false)
 		fmt.Printf("Error Uploading Sql file: %v", err)
@@ -590,6 +590,8 @@ func createController(artifactPath string, errorMessage string) {
 
 	// Istio
 	util.ExecuteCommand(exec.Command(constants.KUBECTL, constants.APPLY, constants.KUBECTL_FLAG, artifactPath+"/k8s-artefacts/system/istio-crds.yaml"), errorMessage)
+	// sleep for few seconds - this is to make sure that the CRDs are properly applied
+	time.Sleep(5 * time.Second)
 
 	// Enabling Istio injection
 	util.ExecuteCommand(exec.Command(constants.KUBECTL, "label", "namespace", "default", "istio-injection=enabled"), errorMessage)

--- a/docs/setup/gcp-setup.md
+++ b/docs/setup/gcp-setup.md
@@ -73,7 +73,7 @@ executing inline command with `cellery setup create gcp [--complete]`.
     ✔ Updating kube config cluster
     ✔ Creating sql instance
     ✔ Creating gcp bucket
-    ✔ Uploading init.sql file to dcp bucket
+    ✔ Uploading init.sql file to GCP bucket
     ✔ Updating bucket permission
     ✔ Importing sql script
     ✔ Updating sql instance


### PR DESCRIPTION
## Purpose
> Add a sleep between applying istio CRD and istio demo yaml. This is to counter intermittently seen error 'Deploying Cellery runtimeError from server (NotFound): error when creating "/home/xxx/.cellery/gcp/artifacts/k8s-artefacts/system/istio-demo-cellery.yaml": the server could not find the requested resource (post destinationrules.networking.istio.io)'.