### PR TITLE
Add support to specify cellery login credentials as flags

### DIFF
--- a/components/cli/cmd/cellery/login.go
+++ b/components/cli/cmd/cellery/login.go
@@ -19,6 +19,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/cellery-io/sdk/components/cli/pkg/commands"
@@ -27,19 +29,33 @@ import (
 
 // newLoginCommand saves the credentials for a particular registry
 func newLoginCommand() *cobra.Command {
+	var username string
+	var password string
 	cmd := &cobra.Command{
 		Use:   "login [registry-url]",
 		Short: "Login to a Cellery Registry",
-		Args:  cobra.MaximumNArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			err := cobra.MaximumNArgs(1)(cmd, args)
+			if err != nil {
+				return err
+			}
+			if password != "" && username == "" {
+				return fmt.Errorf("expects username if the password is provided, username not provided")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 1 {
-				commands.RunLogin(args[0])
+				commands.RunLogin(args[0], username, password)
 			} else {
-				commands.RunLogin(constants.CENTRAL_REGISTRY_HOST)
+				commands.RunLogin(constants.CENTRAL_REGISTRY_HOST, username, password)
 			}
 		},
 		Example: "  cellery login\n" +
+			"  cellery login -u john -p john123" +
 			"  cellery login registry.foo.io",
 	}
+	cmd.Flags().StringVarP(&username, "username", "u", "", "Username for Cellery Registry")
+	cmd.Flags().StringVarP(&password, "password", "p", "", "Password for Cellery Registry")
 	return cmd
 }

--- a/components/cli/pkg/commands/login.go
+++ b/components/cli/pkg/commands/login.go
@@ -31,7 +31,7 @@ import (
 )
 
 // RunLogin requests the user for credentials and logs into a Cellery Registry
-func RunLogin(registryURL string) {
+func RunLogin(registryURL string, username string, password string) {
 	fmt.Println("Logging into Registry: " + util.Bold(registryURL))
 
 	// Instantiating a native keyring
@@ -56,9 +56,15 @@ func RunLogin(registryURL string) {
 	if isCredentialsAlreadyPresent {
 		fmt.Println("Logging in with existing Credentials")
 	} else {
-		registryCredentials.Username, registryCredentials.Password, err = util.RequestCredentials("Docker hub")
-		if err != nil {
-			util.ExitWithErrorMessage("Error occurred while reading Credentials", err)
+		if password == "" {
+			registryCredentials.Username, registryCredentials.Password, err = util.RequestCredentials(
+				"Cellery Registry", username)
+			if err != nil {
+				util.ExitWithErrorMessage("Error occurred while reading Credentials", err)
+			}
+		} else {
+			registryCredentials.Username = username
+			registryCredentials.Password = password
 		}
 	}
 

--- a/components/cli/pkg/commands/pull.go
+++ b/components/cli/pkg/commands/pull.go
@@ -74,7 +74,8 @@ func RunPull(cellImage string, isSilent bool) {
 		if err != nil {
 			if strings.Contains(err.Error(), "401") {
 				// Requesting the credentials since server responded with an Unauthorized status code
-				registryCredentials.Username, registryCredentials.Password, err = util.RequestCredentials("Docker hub")
+				registryCredentials.Username, registryCredentials.Password, err = util.RequestCredentials(
+					"Cellery Registry", "")
 				if err != nil {
 					util.ExitWithErrorMessage("Failed to acquire credentials", err)
 				}

--- a/components/cli/pkg/commands/push.go
+++ b/components/cli/pkg/commands/push.go
@@ -81,7 +81,8 @@ func RunPush(cellImage string) {
 		if err != nil {
 			if strings.Contains(err.Error(), "401") {
 				// Requesting the credentials since server responded with an Unauthorized status code
-				registryCredentials.Username, registryCredentials.Password, err = util.RequestCredentials("Docker hub")
+				registryCredentials.Username, registryCredentials.Password, err = util.RequestCredentials(
+					"Cellery Registry", "")
 				if err != nil {
 					util.ExitWithErrorMessage("Failed to acquire credentials", err)
 				}

--- a/components/cli/pkg/commands/setup_create_existing_cluster.go
+++ b/components/cli/pkg/commands/setup_create_existing_cluster.go
@@ -334,7 +334,7 @@ func createRuntimeOnExistingClusterWithPersistedVolumeWithNfs() error {
 	if err != nil {
 		util.ExitWithErrorMessage("Error occurred while getting user input", err)
 	}
-	dbUserName, dbPassword, err = util.RequestCredentials("Mysql")
+	dbUserName, dbPassword, err = util.RequestCredentials("Mysql", "")
 	if err != nil {
 		util.ExitWithErrorMessage("Error occurred while getting user input", err)
 	}

--- a/components/cli/pkg/util/utils.go
+++ b/components/cli/pkg/util/utils.go
@@ -667,16 +667,22 @@ func ExtractTarGzFile(extractTo, archive_name string) error {
 }
 
 // RequestCredentials requests the credentials form the user and returns them
-func RequestCredentials(credentialType string) (string, string, error) {
+func RequestCredentials(credentialType string, usernameOverride string) (string, string, error) {
 	fmt.Println()
 	fmt.Println(YellowBold("?") + " " + credentialType + " credentials required")
 
-	// Requesting the username from the user
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Print("Username: ")
-	username, err := reader.ReadString('\n')
-	if err != nil {
-		return "", "", err
+	var username string
+	var err error
+	if usernameOverride == "" {
+		// Requesting the username from the user
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Print("Username: ")
+		username, err = reader.ReadString('\n')
+		if err != nil {
+			return "", "", err
+		}
+	} else {
+		username = usernameOverride
 	}
 
 	// Requesting the password from the user
@@ -699,7 +705,7 @@ func RequestCredentials(credentialType string) (string, string, error) {
 
 	if password != confirmPassword {
 		fmt.Println("Password and Confirm password mismatch.")
-		RequestCredentials(credentialType)
+		return RequestCredentials(credentialType, usernameOverride)
 	}
 
 	fmt.Println()

--- a/components/cli/pkg/util/utils.go
+++ b/components/cli/pkg/util/utils.go
@@ -692,21 +692,6 @@ func RequestCredentials(credentialType string, usernameOverride string) (string,
 		return username, "", err
 	}
 	password := string(bytePassword)
-	fmt.Println()
-
-	// Requesting the confirm password from the user
-	fmt.Print("Confirm Password: ")
-	byteConfirmPassword, err := terminal.ReadPassword(0)
-	if err != nil {
-		return username, "", err
-	}
-	confirmPassword := string(byteConfirmPassword)
-	fmt.Println()
-
-	if password != confirmPassword {
-		fmt.Println("Password and Confirm password mismatch.")
-		return RequestCredentials(credentialType, usernameOverride)
-	}
 
 	fmt.Println()
 	return strings.TrimSpace(username), strings.TrimSpace(password), nil


### PR DESCRIPTION
## Purpose
> Add support to specify the credentials as flags.

## Goals
> Support push and pull in CI/CD flows by allowing the user to provide credentials using flags.

## Approach
> The username and password is taken as flags and if they are provided the prompt is not shown to the user and the user will be logged in.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> go1.11 linux/amd64
 
## Learning
> N/A