### PR TITLE
Add username and password flags for push and pull commands

### DIFF
--- a/components/cli/cmd/cellery/pull.go
+++ b/components/cli/cmd/cellery/pull.go
@@ -19,6 +19,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/cellery-io/sdk/components/cli/pkg/commands"
@@ -26,6 +28,8 @@ import (
 )
 
 func newPullCommand() *cobra.Command {
+	var username string
+	var password string
 	cmd := &cobra.Command{
 		Use:   "pull [<registry>/]<organization>/<cell-image>:<version>",
 		Short: "Pull cell image from the remote repository",
@@ -38,13 +42,18 @@ func newPullCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if password != "" && username == "" {
+				return fmt.Errorf("expects username if the password is provided, username not provided")
+			}
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			commands.RunPull(args[0], false)
+			commands.RunPull(args[0], false, username, password)
 		},
 		Example: "  cellery pull cellery-samples/employee:1.0.0\n" +
 			"  cellery pull registry.foo.io/cellery-samples/employee:1.0.0",
 	}
+	cmd.Flags().StringVarP(&username, "username", "u", "", "Username for Cellery Registry")
+	cmd.Flags().StringVarP(&password, "password", "p", "", "Password for Cellery Registry")
 	return cmd
 }

--- a/components/cli/cmd/cellery/push.go
+++ b/components/cli/cmd/cellery/push.go
@@ -19,6 +19,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/cellery-io/sdk/components/cli/pkg/commands"
@@ -26,6 +28,8 @@ import (
 )
 
 func newPushCommand() *cobra.Command {
+	var username string
+	var password string
 	cmd := &cobra.Command{
 		Use:   "push [<registry>/]<organization>/<cell-image>:<version>",
 		Short: "Push cell image to the remote repository",
@@ -38,13 +42,18 @@ func newPushCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if password != "" && username == "" {
+				return fmt.Errorf("expects username if the password is provided, username not provided")
+			}
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			commands.RunPush(args[0])
+			commands.RunPush(args[0], username, password)
 		},
 		Example: "  cellery push cellery-samples/employee:1.0.0\n" +
 			"  cellery push registry.foo.io/cellery-samples/employee:1.0.0",
 	}
+	cmd.Flags().StringVarP(&username, "username", "u", "", "Username for Cellery Registry")
+	cmd.Flags().StringVarP(&password, "password", "p", "", "Password for Cellery Registry")
 	return cmd
 }

--- a/components/cli/pkg/commands/build.go
+++ b/components/cli/pkg/commands/build.go
@@ -223,7 +223,7 @@ func generateMetaData(cellImage *util.CellImage, targetDir string, spinner *util
 			dependencyExists, err := util.FileExists(cellImageZip)
 			if !dependencyExists {
 				spinner.Pause()
-				RunPull(dependency, true)
+				RunPull(dependency, true, "", "")
 				fmt.Println()
 				spinner.Resume()
 			}

--- a/components/cli/pkg/commands/run.go
+++ b/components/cli/pkg/commands/run.go
@@ -788,7 +788,7 @@ func extractImage(cellImage *util.CellImage, spinner *util.Spinner) (string, err
 	}
 	if !imageExists {
 		spinner.Pause()
-		RunPull(cellImageTag, true)
+		RunPull(cellImageTag, true, "", "")
 		fmt.Println()
 		spinner.Resume()
 	}


### PR DESCRIPTION
## Purpose
> Add username and password flags for push and pull commands

## Goals
> Add username and password flags for push and pull commands

## Approach
> The username and password is taken as flags and they are used instead of the stored username and password. If they are not provided, the normal flow is used.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> go1.11 linux/amd64
 
## Learning
> N/A