### PR TITLE
Change Cell Image version validation to support latest and other valid versions

### DIFF
--- a/components/cli/pkg/constants/const.go
+++ b/components/cli/pkg/constants/const.go
@@ -21,7 +21,7 @@ package constants
 const DOMAIN_NAME_PATTERN = "[a-z0-9]+((-|.)[a-z0-9]+)*"
 const CELLERY_ID_PATTERN = "[a-z0-9]+(-[a-z0-9]+)*"
 const CELLERY_ALIAS_PATTERN = "[a-zA-Z0-9_-]+"
-const IMAGE_VERSION_PATTERN = "[0-9]+\\.[0-9]+\\.[0-9]+"
+const IMAGE_VERSION_PATTERN = "[a-z0-9]+((?:-|.)[a-z0-9]+)*"
 const CELL_IMAGE_PATTERN = CELLERY_ID_PATTERN + "\\/" + CELLERY_ID_PATTERN + ":" + IMAGE_VERSION_PATTERN
 const CELL_IMAGE_WITH_REGISTRY_PATTERN = "(" + DOMAIN_NAME_PATTERN + "\\/)?" + CELL_IMAGE_PATTERN
 const DEPENDENCY_LINK_PATTERN = "(" + CELLERY_ID_PATTERN + "\\.)?" + CELLERY_ALIAS_PATTERN + ":" + CELLERY_ID_PATTERN

--- a/components/cli/pkg/util/utils.go
+++ b/components/cli/pkg/util/utils.go
@@ -815,8 +815,7 @@ func ParseImageTag(cellImageString string) (parsedCellImage *CellImage, err erro
 	return cellImage, nil
 }
 
-// ValidateImageTag validates the image tag (without the registry in it). This checks the version to be in the format
-// of semantic versioning
+// ValidateImageTag validates the image tag (without the registry in it).
 func ValidateImageTag(imageTag string) error {
 	r := regexp.MustCompile("^([^/:]*)/([^/:]*):([^/:]*)$")
 	subMatch := r.FindStringSubmatch(imageTag)
@@ -828,29 +827,29 @@ func ValidateImageTag(imageTag string) error {
 	organization := subMatch[1]
 	isValid, err := regexp.MatchString(fmt.Sprintf("^%s$", constants.CELLERY_ID_PATTERN), organization)
 	if err != nil || !isValid {
-		return fmt.Errorf("expects a valid organization name (lower case letters, numbers and dashes), "+
-			"received %s", organization)
+		return fmt.Errorf("expects a valid organization name (lower case letters, numbers and dashes "+
+			"with only letters and numbers at the begining and end), received %s", organization)
 	}
 
 	imageName := subMatch[2]
 	isValid, err = regexp.MatchString(fmt.Sprintf("^%s$", constants.CELLERY_ID_PATTERN), imageName)
 	if err != nil || !isValid {
-		return fmt.Errorf("expects a valid image name (lower case letters, numbers and dashes), "+
-			"received %s", imageName)
+		return fmt.Errorf("expects a valid image name (lower case letters, numbers and dashes "+
+			"with only letters and numbers at the begining and end), received %s", imageName)
 	}
 
 	imageVersion := subMatch[3]
 	isValid, err = regexp.MatchString(fmt.Sprintf("^%s$", constants.IMAGE_VERSION_PATTERN), imageVersion)
 	if err != nil || !isValid {
-		return fmt.Errorf("expects the image version to be in the format of Semantic Versioning "+
-			"(eg:- 1.0.0), received %s", imageVersion)
+		return fmt.Errorf("expects a valid image version (lower case letters, numbers, dashes and dots "+
+			"with only letters and numbers at the begining and end), received %s", imageVersion)
 	}
 
 	return nil
 }
 
 // ValidateImageTag validates the image tag (with the registry in it). The registry is an option element
-// in this validation. This checks the version to be in the format of semantic versioning
+// in this validation.
 func ValidateImageTagWithRegistry(imageTag string) error {
 	r := regexp.MustCompile("^(?:([^/:]*)/)?([^/:]*)/([^/:]*):([^/:]*)$")
 	subMatch := r.FindStringSubmatch(imageTag)
@@ -869,22 +868,22 @@ func ValidateImageTagWithRegistry(imageTag string) error {
 	organization := subMatch[2]
 	isValid, err = regexp.MatchString(fmt.Sprintf("^%s$", constants.CELLERY_ID_PATTERN), organization)
 	if err != nil || !isValid {
-		return fmt.Errorf("expects a valid organization name (lower case letters, numbers and dashes), "+
-			"received %s", organization)
+		return fmt.Errorf("expects a valid organization name (lower case letters, numbers and dashes "+
+			"with only letters and numbers at the begining and end), received %s", organization)
 	}
 
 	imageName := subMatch[3]
 	isValid, err = regexp.MatchString(fmt.Sprintf("^%s$", constants.CELLERY_ID_PATTERN), imageName)
 	if err != nil || !isValid {
-		return fmt.Errorf("expects a valid image name (lower case letters, numbers and dashes), "+
-			"received %s", imageName)
+		return fmt.Errorf("expects a valid image name (lower case letters, numbers and dashes "+
+			"with only letters and numbers at the begining and end), received %s", imageName)
 	}
 
 	imageVersion := subMatch[4]
 	isValid, err = regexp.MatchString(fmt.Sprintf("^%s$", constants.IMAGE_VERSION_PATTERN), imageVersion)
 	if err != nil || !isValid {
-		return fmt.Errorf("expects the image version to be in the format of Semantic Versioning "+
-			"(eg:- 1.0.0), received %s", imageVersion)
+		return fmt.Errorf("expects a valid image version (lower case letters, numbers, dashes and dots "+
+			"with only letters and numbers at the begining and end), received %s", imageVersion)
 	}
 
 	return nil


### PR DESCRIPTION
## Purpose
> Change image validations to support "latest" version and other valid image versions

## Goals
> Change image validations to support "latest" version and other valid image versions

## Approach
> Change image validations to support "latest" version and other valid image versions

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> go1.11 linux/amd64
 
## Learning
> N/A