### PR TITLE
Add support to use file based credentials saving when keyring is not available

### DIFF
--- a/components/cli/pkg/commands/logout.go
+++ b/components/cli/pkg/commands/logout.go
@@ -21,9 +21,7 @@ package commands
 import (
 	"fmt"
 
-	"github.com/99designs/keyring"
-
-	"github.com/cellery-io/sdk/components/cli/pkg/constants"
+	"github.com/cellery-io/sdk/components/cli/pkg/registry/credentials"
 	"github.com/cellery-io/sdk/components/cli/pkg/util"
 )
 
@@ -31,31 +29,21 @@ import (
 func RunLogout(registryURL string) {
 	fmt.Print("Logging out from Registry: " + util.Bold(registryURL))
 
-	// Instantiating a native keyring
-	ring, err := keyring.Open(keyring.Config{
-		ServiceName: constants.CELLERY_HUB_KEYRING_NAME,
-	})
+	credManager, err := credentials.NewCredManager()
 	if err != nil {
-		util.ExitWithErrorMessage("Error occurred while logging out", err)
+		util.ExitWithErrorMessage("Error occurred while creating Credentials Manager", err)
 	}
 
 	// Checking if the credentials are present
-	keyList, err := ring.Keys()
+	isCredentialsPresent, err := credManager.HasCredentials(registryURL)
 	if err != nil {
-		util.ExitWithErrorMessage("Error occurred while logging out", err)
-	}
-	var isCredentialsPresent bool
-	for _, key := range keyList {
-		if key == registryURL {
-			isCredentialsPresent = true
-			break
-		}
+		util.ExitWithErrorMessage("Error occurred while checking whether credentials are already saved", err)
 	}
 
 	if !isCredentialsPresent {
 		fmt.Printf("\nYou have not logged into %s Registry\n", util.Bold(registryURL))
 	} else {
-		err = ring.Remove(registryURL)
+		err = credManager.RemoveCredentials(registryURL)
 		if err != nil {
 			util.ExitWithErrorMessage("Error occurred while removing Credentials", err)
 		}

--- a/components/cli/pkg/commands/pull.go
+++ b/components/cli/pkg/commands/pull.go
@@ -19,7 +19,6 @@
 package commands
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -27,11 +26,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/99designs/keyring"
 	"github.com/nokia/docker-registry-client/registry"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/cellery-io/sdk/components/cli/pkg/constants"
+	"github.com/cellery-io/sdk/components/cli/pkg/registry/credentials"
 	"github.com/cellery-io/sdk/components/cli/pkg/util"
 )
 
@@ -43,7 +42,8 @@ func RunPull(cellImage string, isSilent bool, username string, password string) 
 		util.ExitWithErrorMessage("Error occurred while parsing cell image", err)
 	}
 
-	var registryCredentials = &util.RegistryCredentials{
+	var registryCredentials = &credentials.RegistryCredentials{
+		Registry: parsedCellImage.Registry,
 		Username: username,
 		Password: password,
 	}
@@ -53,24 +53,23 @@ func RunPull(cellImage string, isSilent bool, username string, password string) 
 	isCredentialsPresent := err == nil && registryCredentials.Username != "" &&
 		registryCredentials.Password != ""
 
-	var ring keyring.Keyring
+	var credManager credentials.CredManager
 	if !isCredentialsPresent {
-		// Instantiating a native keyring
-		ring, err := keyring.Open(keyring.Config{
-			ServiceName: constants.CELLERY_HUB_KEYRING_NAME,
-		})
+		credManager, err = credentials.NewCredManager()
 		if err != nil {
-			util.ExitWithErrorMessage("Error occurred while logging out", err)
+			util.ExitWithErrorMessage("Unable to use a Credentials Manager, "+
+				"please use inline flags instead", err)
 		}
-
-		if err == nil {
-			ringItem, err := ring.Get(parsedCellImage.Registry)
-			if err == nil && ringItem.Data != nil {
-				err = json.Unmarshal(ringItem.Data, registryCredentials)
-			}
+		savedCredentials, err := credManager.GetCredentials(parsedCellImage.Registry)
+		if err != nil {
+			util.ExitWithErrorMessage("failed to read saved credentials", err)
 		}
-		isCredentialsPresent = err == nil && registryCredentials.Username != "" &&
-			registryCredentials.Password != ""
+		if savedCredentials.Username != "" && savedCredentials.Password != "" {
+			registryCredentials = savedCredentials
+			isCredentialsPresent = true
+		} else {
+			isCredentialsPresent = false
+		}
 	}
 
 	if isCredentialsPresent {
@@ -98,16 +97,8 @@ func RunPull(cellImage string, isSilent bool, username string, password string) 
 					util.ExitWithErrorMessage("Failed to pull image", err)
 				}
 
-				// Saving credentials
-				credentialsData, err := json.Marshal(registryCredentials)
-				if err != nil {
-					util.ExitWithErrorMessage("Error occurred while saving Credentials", err)
-				}
-				if ring != nil {
-					err = ring.Set(keyring.Item{
-						Key:  parsedCellImage.Registry,
-						Data: credentialsData,
-					})
+				if credManager != nil {
+					err = credManager.StoreCredentials(registryCredentials)
 					if err == nil {
 						fmt.Printf("\n%s Saved Credentials for %s Registry", util.GreenBold("\U00002714"),
 							util.Bold(parsedCellImage.Registry))
@@ -122,7 +113,6 @@ func RunPull(cellImage string, isSilent bool, username string, password string) 
 		}
 	}
 	if !isSilent {
-		fmt.Println()
 		util.PrintSuccessMessage(fmt.Sprintf("Successfully pulled cell image: %s", util.Bold(cellImage)))
 		util.PrintWhatsNextMessage("run the image", "cellery run "+cellImage)
 	}

--- a/components/cli/pkg/constants/const.go
+++ b/components/cli/pkg/constants/const.go
@@ -123,8 +123,6 @@ const KUBECTL_FLAG = "-f"
 const IGNORE_NOT_FOUND = "--ignore-not-found"
 const BALLERINA_PRINT_RETURN_FLAG = "--printreturn"
 
-const CELLERY_HUB_KEYRING_NAME = "hubcelleryio"
-
 const BASIC = "Basic"
 const COMPLETE = "Complete"
 

--- a/components/cli/pkg/registry/credentials/credmanager.go
+++ b/components/cli/pkg/registry/credentials/credmanager.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package credentials
+
+import "fmt"
+
+// RegistryCredentials holds the credentials of a registry
+type RegistryCredentials struct {
+	Registry string
+	Username string
+	Password string
+}
+
+// CredManager interface which defines the behaviour of all the credential managers.
+type CredManager interface {
+	// StoreCredentials stores the credentials in the relevant credentials store. The Registry field of the credentials
+	// struct is required for this operation
+	StoreCredentials(credentials *RegistryCredentials) error
+
+	// GetCredentials retrieves the credentials from the relevant credentials store
+	GetCredentials(registry string) (*RegistryCredentials, error)
+
+	// RemoveCredentials removes the credentials from the relevant credentials store
+	RemoveCredentials(registry string) error
+
+	// HasCredentials checks whether the credentials are currently stored in the relevant credentials store
+	HasCredentials(registry string) (bool, error)
+}
+
+// NewCredManager creates a new credentials manager instance
+func NewCredManager() (CredManager, error) {
+	var credManager CredManager
+	credManager, err := NewKeyringCredManager()
+	if err == nil {
+		return credManager, nil
+	}
+	credManager, err = NewFileCredentialsManager()
+	if err == nil {
+		return credManager, nil
+	}
+	return nil, fmt.Errorf("failed to initialize a suitable credentials manager")
+}

--- a/components/cli/pkg/registry/credentials/file.go
+++ b/components/cli/pkg/registry/credentials/file.go
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package credentials
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path"
+
+	"github.com/cellery-io/sdk/components/cli/pkg/constants"
+	"github.com/cellery-io/sdk/components/cli/pkg/util"
+)
+
+// Credentials are stored in a file in the Cellery user home. Only the owner of the file has permissions to this file.
+const credentialsFileName = "credentials"
+const credentialsFilePermissions os.FileMode = 0600
+
+// FileCredentialsManager manages the credentials in credentials file
+type FileCredentialsManager struct {
+	credFile string
+}
+
+// NewFileCredentialsManager creates a new File based Credentials Manager
+func NewFileCredentialsManager() (*FileCredentialsManager, error) {
+	currentUser, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("failed to identify the current user due to: %v", err)
+	}
+	credentialsFile := path.Join(currentUser.HomeDir, constants.CELLERY_HOME, credentialsFileName)
+	credManager := &FileCredentialsManager{
+		credFile: credentialsFile,
+	}
+	return credManager, nil
+}
+
+// StoreCredentials stores the credentials in credentials file
+func (credManager FileCredentialsManager) StoreCredentials(credentials *RegistryCredentials) error {
+	if credentials.Registry == "" {
+		return fmt.Errorf("registry to which the credentials belongs to is required for storing credentials")
+	}
+	credentialsMap, err := credManager.readCredentials()
+	if err != nil {
+		return fmt.Errorf("failed to fetch credentials due to: %v", err)
+	}
+	credentialsMap[credentials.Registry] = credentials
+	err = credManager.writeCredentials(credentialsMap)
+	if err != nil {
+		return fmt.Errorf("failed to save credentials due to: %v", err)
+	}
+	return nil
+}
+
+// GetCredentials retrieves the credentials from the credentials file
+func (credManager FileCredentialsManager) GetCredentials(registry string) (*RegistryCredentials, error) {
+	if registry == "" {
+		return nil, fmt.Errorf(
+			"registry to which the credentials belongs to is required for retrieving credentials")
+	}
+	credentialsMap, err := credManager.readCredentials()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch credentials due to: %v", err)
+	}
+	credentials := credentialsMap[registry]
+	if credentials == nil {
+		credentials = &RegistryCredentials{}
+	}
+	credentials.Registry = registry
+	return credentials, nil
+}
+
+// RemoveCredentials removes the stored credentials from the credentials file
+func (credManager FileCredentialsManager) RemoveCredentials(registry string) error {
+	if registry == "" {
+		return fmt.Errorf("registry to which the credentials belongs to is required for removing credentials")
+	}
+	credentialsMap, err := credManager.readCredentials()
+	if err != nil {
+		return fmt.Errorf("failed to fetch credentials due to: %v", err)
+	}
+	delete(credentialsMap, registry)
+	err = credManager.writeCredentials(credentialsMap)
+	if err != nil {
+		return fmt.Errorf("failed to update credentials file due to: %v", err)
+	}
+	return nil
+}
+
+// IsRegistryPresent checks if the registry credentials exists in the credentials file
+func (credManager FileCredentialsManager) HasCredentials(registry string) (bool, error) {
+	if registry == "" {
+		return false, fmt.Errorf(
+			"registry to which the credentials belongs to is required for checking for credentials")
+	}
+	credentialsMap, err := credManager.readCredentials()
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch credentials due to: %v", err)
+	}
+	_, hasKey := credentialsMap[registry]
+	return hasKey, nil
+}
+
+// readCredentials reads the credentials stored in the credentials file
+func (credManager FileCredentialsManager) readCredentials() (map[string]*RegistryCredentials, error) {
+	// Reading the existing credentials in the file if it exists
+	fileExists, err := util.FileExists(credManager.credFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to store the credentials in file due to: %v", err)
+	}
+	storedCredentials := &map[string]*RegistryCredentials{}
+	if fileExists {
+		credFileBytes, err := ioutil.ReadFile(credManager.credFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read the existing credentials file due to: %v", err)
+		}
+		err = json.Unmarshal(credFileBytes, storedCredentials)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode the credentials json due to: %v", err)
+		}
+	}
+	return *storedCredentials, nil
+}
+
+// writeCredentials writes the credentials map to the credentials credentials file
+func (credManager FileCredentialsManager) writeCredentials(credentialsMap map[string]*RegistryCredentials) error {
+	credentialsBytes, err := json.Marshal(credentialsMap)
+	if err != nil {
+		return fmt.Errorf("failed to encode credentials for storing due to: %v", err)
+	}
+	err = ioutil.WriteFile(credManager.credFile, credentialsBytes, credentialsFilePermissions)
+	if err != nil {
+		return fmt.Errorf("failed to store the credentials in file due to: %v", err)
+	}
+	return nil
+}

--- a/components/cli/pkg/registry/credentials/keyring.go
+++ b/components/cli/pkg/registry/credentials/keyring.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package credentials
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/99designs/keyring"
+)
+
+// celleryHubKeyringName is the name of the keyring that will be created to store the credentials
+const celleryHubKeyringName = "registrycelleryio"
+
+// KeyringCredManager holds the core of the KeyringCredManager which can be used to store the registry
+// credentials in the native keyring
+type KeyringCredManager struct {
+	ring keyring.Keyring
+}
+
+// NewKeyringCredManager creates a new native keyring based credentials manager
+func NewKeyringCredManager() (*KeyringCredManager, error) {
+	ring, err := keyring.Open(keyring.Config{
+		ServiceName:              celleryHubKeyringName,
+		FileDir:                  "~/.cellery/credentials",
+		KeychainTrustApplication: false,
+		AllowedBackends: []keyring.BackendType{keyring.SecretServiceBackend, keyring.KeychainBackend,
+			keyring.KWalletBackend, keyring.WinCredBackend, keyring.PassBackend},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("keyring Credentials Manager not supported due to: %v", err)
+	}
+	credManager := &KeyringCredManager{
+		ring: ring,
+	}
+	return credManager, nil
+}
+
+// StoreCredentials stores the credentials in the native keyring
+func (credManager KeyringCredManager) StoreCredentials(credentials *RegistryCredentials) error {
+	if credentials.Registry == "" {
+		return fmt.Errorf("registry to which the credentials belongs to is required for storing credentials")
+	}
+	credentialsData, err := json.Marshal(credentials)
+	if err != nil {
+		return fmt.Errorf("failed to create credentials json due to: %v", err)
+	}
+	err = credManager.ring.Set(keyring.Item{
+		Key:  credentials.Registry,
+		Data: credentialsData,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to store credentials in the native keyring due to: %v", err)
+	}
+	return nil
+}
+
+// GetCredentials retrieves the previous stored credentials from the keyring
+func (credManager KeyringCredManager) GetCredentials(registry string) (*RegistryCredentials, error) {
+	if registry == "" {
+		return nil, fmt.Errorf(
+			"registry to which the credentials belongs to is required for retrieving credentials")
+	}
+	ringItem, err := credManager.ring.Get(registry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get credentials from the native keyring due to: %v", err)
+	}
+	var registryCredentials = &RegistryCredentials{
+		Registry: registry,
+	}
+	if ringItem.Data == nil {
+		return registryCredentials, nil
+	}
+	err = json.Unmarshal(ringItem.Data, registryCredentials)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode the stored credentials due to: %v", err)
+	}
+	return registryCredentials, err
+}
+
+// RemoveCredentials removes the stored credentials from the keyring
+func (credManager KeyringCredManager) RemoveCredentials(registry string) error {
+	if registry == "" {
+		return fmt.Errorf("registry to which the credentials belongs to is required for removing credentials")
+	}
+	err := credManager.ring.Remove(registry)
+	if err != nil {
+		return fmt.Errorf("failed to remove credentials from the keyring due to: %v", err)
+	}
+	return nil
+}
+
+// IsRegistryPresent checks if the registry (key in the keyring) exists
+func (credManager KeyringCredManager) HasCredentials(registry string) (bool, error) {
+	if registry == "" {
+		return false, fmt.Errorf(
+			"registry to which the credentials belongs to is required for checking for credentials")
+	}
+	keyList, err := credManager.ring.Keys()
+	if err != nil {
+		if strings.Contains(err.Error(), "The collection \""+celleryHubKeyringName+"\" does not exist") {
+			return false, nil
+		} else {
+			return false, fmt.Errorf(
+				"failed to check if the credentials exists due to: %v", err)
+		}
+	}
+	var isCredentialsPresent bool
+	for _, key := range keyList {
+		if key == registry {
+			isCredentialsPresent = true
+			break
+		}
+	}
+	return isCredentialsPresent, nil
+}


### PR DESCRIPTION
## Purpose
> Add support to use file based credentials saving when keyring is not available. This is specially useful when the CLI needs  to login inside a headless VM.

## Goals
> Add support to login when the keyring is not available

## Approach
> When creating a keyring fails, the CLI falls back to the file based credentials saving.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> go1.11 linux/amd64
  Ubuntu 18
  Ubuntu Server 16

## Learning
> N/A