### PR TITLE
Allow Cellery Hub port to be defined in the cellery push/pull/login

### DIFF
--- a/components/cli/pkg/constants/const.go
+++ b/components/cli/pkg/constants/const.go
@@ -18,7 +18,7 @@
 
 package constants
 
-const DOMAIN_NAME_PATTERN = "[a-z0-9]+((-|.)[a-z0-9]+)*"
+const DOMAIN_NAME_PATTERN = "[a-z0-9]+((?:-|.)[a-z0-9]+)*(:[0-9]+)?"
 const CELLERY_ID_PATTERN = "[a-z0-9]+(-[a-z0-9]+)*"
 const CELLERY_ALIAS_PATTERN = "[a-zA-Z0-9_-]+"
 const IMAGE_VERSION_PATTERN = "[a-z0-9]+((?:-|.)[a-z0-9]+)*"

--- a/components/cli/pkg/util/utils.go
+++ b/components/cli/pkg/util/utils.go
@@ -851,7 +851,7 @@ func ValidateImageTag(imageTag string) error {
 // ValidateImageTag validates the image tag (with the registry in it). The registry is an option element
 // in this validation.
 func ValidateImageTagWithRegistry(imageTag string) error {
-	r := regexp.MustCompile("^(?:([^/:]*)/)?([^/:]*)/([^/:]*):([^/:]*)$")
+	r := regexp.MustCompile("^(?:([^/]*)/)?([^/:]*)/([^/:]*):([^/:]*)$")
 	subMatch := r.FindStringSubmatch(imageTag)
 
 	if subMatch == nil {


### PR DESCRIPTION
## Purpose
> Allow the user to specify the Cellery Registry port when pushing to a custom registry

## Goals
> Allow the user to specify the Cellery Registry port when pushing to a custom registry

## Approach
> The regexes and validations are updated accordingly.

## User stories
> As a Cellery user, I need to push to a Cellery Registry listening on a port different from the default port.

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> go version go1.11 linux/amd64

## Learning
> N/A