### PR TITLE
Remove repo name from random instance name generation

### DIFF
--- a/components/cli/pkg/commands/run.go
+++ b/components/cli/pkg/commands/run.go
@@ -951,8 +951,7 @@ func generateRandomInstanceName(dependencyMetaData *util.CellImageMetaData) (str
 	uuid := fmt.Sprintf("%x", u)
 
 	// Generating random instance name
-	return dependencyMetaData.Organization + "-" + dependencyMetaData.Name + "-" +
-		strings.Replace(dependencyMetaData.Version, ".", "-", -1) + "-" + uuid, nil
+	return dependencyMetaData.Name + "-" + strings.Replace(dependencyMetaData.Version, ".", "-", -1) + "-" + uuid, nil
 }
 
 // Get list of yaml files in a dir.


### PR DESCRIPTION
## Purpose
> Removes repo name from random instance name generation when **-n** flag is not given with **cellery run** command.

## Goals
> Minimize probability of hitting the k8s character limit for resource names