### PR TITLE
support overriding existing env vars

### DIFF
--- a/components/cli/pkg/commands/run.go
+++ b/components/cli/pkg/commands/run.go
@@ -925,11 +925,6 @@ func startCellInstance(imageDir string, instanceName string, runningNode *depend
 			dockerImageDir := re.ReplaceAllString(imageDir, "/home/cellery/.cellery/tmp/cellery-cell-image")
 
 			cmd = exec.Command("docker", "exec", "-e", constants.CELLERY_IMAGE_DIR_ENV_VAR+"="+dockerImageDir)
-			if len(envVars) != 0 {
-				for _, envVar := range envVars {
-					cmd.Args = append(cmd.Args, "-e", envVar.Key+"="+envVar.Value)
-				}
-			}
 			shellEnvs := os.Environ()
 			// check if any env var prepended with `CELLERY` exists. If so, set them to docker exec command.
 			if len(shellEnvs) != 0 {
@@ -937,6 +932,13 @@ func startCellInstance(imageDir string, instanceName string, runningNode *depend
 					if strings.HasPrefix(shellEnv, "CELLERY") {
 						cmd.Args = append(cmd.Args, "-e", shellEnv)
 					}
+				}
+			}
+			// set any explicitly passed env vars in cellery run command to the docker exec.
+			// This will override any env vars with identical names (prefixed with 'CELLERY') set previously.
+			if len(envVars) != 0 {
+				for _, envVar := range envVars {
+					cmd.Args = append(cmd.Args, "-e", envVar.Key+"="+envVar.Value)
 				}
 			}
 			cmd.Args = append(cmd.Args, "-w", "/home/cellery", "-u", "1000",


### PR DESCRIPTION
## Purpose
> Support overriding any previously set env vars by explicitly passing to the `cellery run` command.