### PR TITLE
handle b7a not found in cellery version cmd

### DIFF
--- a/components/cli/pkg/commands/version.go
+++ b/components/cli/pkg/commands/version.go
@@ -60,11 +60,12 @@ func RunVersion() {
 	balVersionCmd := exec.Command(exePath+"ballerina", "version")
 	balResult, err := balVersionCmd.Output()
 	if err != nil {
-		util.ExitWithErrorMessage("Ballerina not found",
-			errors.New("unable to find ballerina in executable"))
+		// Having b7a locally is optional since the cellery build and run can be invoked via a docker container.
+		fmt.Println(" Ballerina not found locally")
+	} else {
+		balVersion := string(balResult)
+		fmt.Println(" Version:\t\t" + strings.TrimSpace(strings.Split(balVersion, " ")[1]))
 	}
-	balVersion := string(balResult)
-	fmt.Println(" Version:\t\t" + strings.TrimSpace(strings.Split(balVersion, " ")[1]))
 
 	// Printing Kubernetes version information
 	_, _ = boldWhite.Println("\nKubernetes")


### PR DESCRIPTION
## Purpose
> Since having b7a locally is optional, the cellery version will output an error. This PR fixes the issue by printing a info log if no ballerina is installed locally. 