### PR TITLE
Update CLI version to be generated during build creation

### DIFF
--- a/components/cli/pkg/commands/version.go
+++ b/components/cli/pkg/commands/version.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/cellery-io/sdk/components/cli/pkg/version"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -46,7 +47,7 @@ func RunVersion() {
 
 	// Printing Cellery version information
 	_, _ = boldWhite.Println("Cellery:")
-	fmt.Println(" CLI Version:\t\t0.2.1")
+	fmt.Printf(" CLI Version:\t\t%s\n", version.BuildVersion())
 	fmt.Printf(" OS/Arch:\t\t%s/%s\n", runtime.GOOS, runtime.GOARCH)
 	//fmt.Println(" Experimental:\t\ttrue") // TODO
 


### PR DESCRIPTION
At the moment, CLI version is hardcoded. This was updated to be generated during the build creation time instead of hardcoding.
Version can be defined when creating the build by executing the build command as follows
`VERSION=<VERSION> make build-mac-installer`