### PR TITLE
Add support to add build time cellery version to Cell Images

### DIFF
--- a/components/cli/pkg/commands/build.go
+++ b/components/cli/pkg/commands/build.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/cellery-io/sdk/components/cli/pkg/constants"
 	"github.com/cellery-io/sdk/components/cli/pkg/util"
+	"github.com/cellery-io/sdk/components/cli/pkg/version"
 )
 
 // RunBuild executes the cell's build life cycle method and saves the generated cell image to the local repo.
@@ -276,7 +277,8 @@ func generateMetaData(cellImage *util.CellImage, targetDir string, spinner *util
 	}
 
 	metadata := &util.CellImageMetaData{
-		BuildTimestamp: time.Now().Unix(),
+		BuildCelleryVersion: version.BuildVersion(),
+		BuildTimestamp:      time.Now().Unix(),
 	}
 	err = json.Unmarshal(metadataJSON, metadata)
 	if err != nil {

--- a/components/cli/pkg/util/structs.go
+++ b/components/cli/pkg/util/structs.go
@@ -197,12 +197,13 @@ type CellImageName struct {
 
 type CellImageMetaData struct {
 	CellImageName
-	Labels         map[string]string             `json:"labels"`
-	DockerImages   []string                      `json:"dockerImages"`
-	BuildTimestamp int64                         `json:"buildTimestamp"`
-	Ingresses      []string                      `json:"ingresses"`
-	Components     []string                      `json:"components"`
-	Dependencies   map[string]*CellImageMetaData `json:"dependencies"`
+	Labels              map[string]string             `json:"labels"`
+	DockerImages        []string                      `json:"dockerImages"`
+	BuildTimestamp      int64                         `json:"buildTimestamp"`
+	BuildCelleryVersion string                        `json:"buildCelleryVersion"`
+	Ingresses           []string                      `json:"ingresses"`
+	Components          []string                      `json:"components"`
+	Dependencies        map[string]*CellImageMetaData `json:"dependencies"`
 }
 
 type progressWriter struct {


### PR DESCRIPTION
## Purpose
> Add support to add build time cellery version to Cell Images

## Goals
> Add support to add build time cellery version to Cell Images

## Approach
> The version of the Cellery installation is added to the Cell Image at build time. When an image is pulled, the versions are compared (whether they are equal) and a warning is shown if they do not match. A proper major, minor, patch version related compatibility check should be added later.

## User stories
> As a user, I expect a warning when version incompatibility may occur.

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A