### PR TITLE
Update CLI delete command arguements

### DIFF
--- a/components/cli/cmd/cellery/delete_image.go
+++ b/components/cli/cmd/cellery/delete_image.go
@@ -25,23 +25,29 @@ import (
 )
 
 func newDeleteImageCommand() *cobra.Command {
+	var deleteAll = false
+	var regex = ""
 	cmd := &cobra.Command{
 		Use:   "delete <cell-image(s)>",
 		Short: "Delete cell image(s) from repo",
 		Args: func(cmd *cobra.Command, args []string) error {
-			err := cobra.ExactArgs(1)(cmd, args)
-			if err != nil {
-				return err
+			if !deleteAll && regex == "" {
+				err := cobra.MinimumNArgs(1)(cmd, args)
+				if err != nil {
+					return err
+				}
 			}
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			commands.RunDeleteImage(args[0])
+			commands.RunDeleteImage(args, regex, deleteAll)
 		},
-		Example: "  cellery delete cellery-samples/employee:1.0.0\n" +
-			"  cellery delete 'cellery-samples/.*:1.0.0'\n" +
-			"  cellery delete '.*/employee:.*',cellery delete cellery-samples/employee:1.0.0\n" +
-			"  cellery delete '.*'",
+		Example: "  cellery delete cellery-samples/employee:1.0.0  my-org/hr:1.0.0\n" +
+			"  cellery delete cellery-samples/employee:1.0.0 --regex '.*/employee:.*'\n" +
+			"  cellery delete --all\n" +
+			"  cellery delete --regex .*/employee:.*\n",
 	}
+	cmd.Flags().BoolVar(&deleteAll, "all", false, "Delete all cell images")
+	cmd.Flags().StringVar(&regex, "regex", "", "Regular expression of cell images to be deleted")
 	return cmd
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -139,18 +139,18 @@ Ex:
 
 #### Cellery delete
 
-Delete cell images. This command will delete one or more cell images from cellery local repository.
+Delete cell images. This command will delete one or more cell images from cellery local repository. Users can also delete all cell images by executing the command with "--all" flag.
 
 ##### Parameters:
 
-* _cell image names: This is a comma separated list of existing cell images and regular expressions of cell images._
+* _cell image names: This is a space separated list of existing cell images and/or regular expression of cell images._
 
 Ex:
  ```
-   cellery delete cellery-samples/employee:1.0.0
-   cellery delete 'cellery-samples/.*:1.0.0'
-   cellery delete '.*/employee:.*',cellery delete cellery-samples/employee:1.0.0
-   cellery delete '.*'
+   cellery delete cellery-samples/employee:1.0.0 cellery-samples/hr:1.0.0
+   cellery delete --regex 'cellery-samples/.*:1.0.0'
+   cellery delete cellery-samples/employee:1.0.0 --regex '.*/employee:.*'
+   cellery delete --all
  ```
 
  [Back to Command List](#cellery-cli-commands)


### PR DESCRIPTION
Updated the expected arguments of `cellery delete` command.
* cellery delete --all would delete all cell images.
* cellery delete <image_1> <image_2> <image_3> would delete a list of images.
* cellery delete --regex <regular_expression> would delete all cell images that match the regex.

Docs were updated to reflect the changes. 