### PR TITLE
Update CLI login to not consider port

### DIFF
--- a/components/cli/pkg/registry/credentials/credentials.go
+++ b/components/cli/pkg/registry/credentials/credentials.go
@@ -164,7 +164,7 @@ func getTokenFromCode(code string, port int, conf *config.Conf) string {
 	tokenUrl := conf.Idp.Url + "/oauth2/token"
 	responseBody := "client_id=" + conf.Idp.ClientId +
 		"&grant_type=authorization_code&code=" + code +
-		"&redirect_uri=" + fmt.Sprint(callBackUrl, port)
+		"&redirect_uri=" + fmt.Sprintf(callBackUrl, port)
 	body := strings.NewReader(responseBody)
 	// Token request
 	req, err := http.NewRequest("POST", tokenUrl, body)

--- a/components/cli/pkg/registry/credentials/credmanager.go
+++ b/components/cli/pkg/registry/credentials/credmanager.go
@@ -18,7 +18,10 @@
 
 package credentials
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // RegistryCredentials holds the credentials of a registry
 type RegistryCredentials struct {
@@ -55,4 +58,9 @@ func NewCredManager() (CredManager, error) {
 		return credManager, nil
 	}
 	return nil, fmt.Errorf("failed to initialize a suitable credentials manager")
+}
+
+// Get a proper key for a registry
+func getCredManagerKeyForRegistry(registry string) string {
+	return strings.Split(registry, ":")[0]
 }

--- a/components/cli/pkg/registry/credentials/file.go
+++ b/components/cli/pkg/registry/credentials/file.go
@@ -57,11 +57,13 @@ func (credManager FileCredentialsManager) StoreCredentials(credentials *Registry
 	if credentials.Registry == "" {
 		return fmt.Errorf("registry to which the credentials belongs to is required for storing credentials")
 	}
+	registryKey := getCredManagerKeyForRegistry(credentials.Registry)
+
 	credentialsMap, err := credManager.readCredentials()
 	if err != nil {
 		return fmt.Errorf("failed to fetch credentials due to: %v", err)
 	}
-	credentialsMap[credentials.Registry] = credentials
+	credentialsMap[registryKey] = credentials
 	err = credManager.writeCredentials(credentialsMap)
 	if err != nil {
 		return fmt.Errorf("failed to save credentials due to: %v", err)
@@ -75,11 +77,13 @@ func (credManager FileCredentialsManager) GetCredentials(registry string) (*Regi
 		return nil, fmt.Errorf(
 			"registry to which the credentials belongs to is required for retrieving credentials")
 	}
+	registryKey := getCredManagerKeyForRegistry(registry)
+
 	credentialsMap, err := credManager.readCredentials()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch credentials due to: %v", err)
 	}
-	credentials := credentialsMap[registry]
+	credentials := credentialsMap[registryKey]
 	if credentials == nil {
 		credentials = &RegistryCredentials{}
 	}
@@ -92,11 +96,13 @@ func (credManager FileCredentialsManager) RemoveCredentials(registry string) err
 	if registry == "" {
 		return fmt.Errorf("registry to which the credentials belongs to is required for removing credentials")
 	}
+	registryKey := getCredManagerKeyForRegistry(registry)
+
 	credentialsMap, err := credManager.readCredentials()
 	if err != nil {
 		return fmt.Errorf("failed to fetch credentials due to: %v", err)
 	}
-	delete(credentialsMap, registry)
+	delete(credentialsMap, registryKey)
 	err = credManager.writeCredentials(credentialsMap)
 	if err != nil {
 		return fmt.Errorf("failed to update credentials file due to: %v", err)
@@ -110,11 +116,13 @@ func (credManager FileCredentialsManager) HasCredentials(registry string) (bool,
 		return false, fmt.Errorf(
 			"registry to which the credentials belongs to is required for checking for credentials")
 	}
+	registryKey := getCredManagerKeyForRegistry(registry)
+
 	credentialsMap, err := credManager.readCredentials()
 	if err != nil {
 		return false, fmt.Errorf("failed to fetch credentials due to: %v", err)
 	}
-	_, hasKey := credentialsMap[registry]
+	_, hasKey := credentialsMap[registryKey]
 	return hasKey, nil
 }
 


### PR DESCRIPTION
## Purpose
> Update the CLI hub login to not consider port in the registry URL.

## Goals
> Update the CLI hub login to not consider port in registry URL in favor of issues that occurs on different platforms.

## Approach
> The port part is removed from the registry URL inside the credential managers.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A