### PR TITLE
Fix docker working dir bug

### DIFF
--- a/components/cli/pkg/commands/build.go
+++ b/components/cli/pkg/commands/build.go
@@ -171,8 +171,9 @@ func RunBuild(tag string, fileName string) {
 			}
 			time.Sleep(5 * time.Second)
 		}
+		balFileName := filepath.Base(tempBuildFileName)
 		cmd = exec.Command("docker", "exec", "-w", "/home/cellery/src", "-u", "1000",
-			strings.TrimSpace(string(out)), constants.DOCKER_CLI_BALLERINA_EXECUTABLE_PATH, "run", tempBuildFileName, "build", string(iName), "{}")
+			strings.TrimSpace(string(out)), constants.DOCKER_CLI_BALLERINA_EXECUTABLE_PATH, "run", "target/"+balFileName, "build", string(iName), "{}")
 	}
 	execError := ""
 	stderrReader, _ := cmd.StderrPipe()


### PR DESCRIPTION
## Purpose
When ballerina is not installed, CLI will be pulling ballerina runtime docker. This PR fixes a bug with docker working directory.