### PR TITLE
Add required CORS headers to the Server opened for SDK login

### DIFF
--- a/components/cli/pkg/registry/credentials/credentials.go
+++ b/components/cli/pkg/registry/credentials/credentials.go
@@ -84,7 +84,7 @@ func FromBrowser(username string, isAuthorized chan bool, done chan bool) (strin
 				if authorized {
 					http.Redirect(w, r, conf.Hub.Url+"/sdk/auth-success", http.StatusSeeOther)
 				} else {
-					// todo add authentication fail url
+					http.Redirect(w, r, conf.Hub.Url+"/sdk/auth-failure", http.StatusSeeOther)
 					fmt.Println("\n\U0000274C Failed to authenticate")
 				}
 				flusher, ok := w.(http.Flusher)

--- a/components/cli/pkg/registry/credentials/credentials.go
+++ b/components/cli/pkg/registry/credentials/credentials.go
@@ -74,6 +74,8 @@ func FromBrowser(username string, isAuthorized chan bool, done chan bool) (strin
 			code = r.Form.Get("code")
 			ping := r.Form.Get("ping")
 			if ping == "true" {
+				w.Header().Set("Access-Control-Allow-Origin", conf.Hub.Url)
+				w.Header().Set("Access-Control-Allow-Methods", http.MethodGet)
 				w.WriteHeader(http.StatusOK)
 			}
 			if code != "" {


### PR DESCRIPTION
## Purpose
> Since the CORS headers are required for pinging the endpoint exposed for SDK login, the headers were added when a ping request is received

## Goals
> Add required CORS headers to the Server opened for SDK login

## Approach
> Add required CORS headers to the Server opened for SDK login

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A