### PR TITLE
Add flag to use insecure server connections over SSL

### DIFF
--- a/components/cli/cmd/cellery/cellery.go
+++ b/components/cli/cmd/cellery/cellery.go
@@ -34,11 +34,15 @@ import (
 
 func newCliCommand() *cobra.Command {
 	var verboseMode = false
+	var insecureMode = false
 	cmd := &cobra.Command{
 		Use:   "cellery <command>",
 		Short: "Manage immutable cell based applications",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			kubectl.SetVerboseMode(verboseMode)
+			if insecureMode {
+				http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+			}
 		},
 	}
 
@@ -68,12 +72,12 @@ func newCliCommand() *cobra.Command {
 		newRouteTrafficCommand(),
 	)
 	cmd.PersistentFlags().BoolVarP(&verboseMode, "verbose", "v", false, "Run on verbose mode")
+	cmd.PersistentFlags().BoolVarP(&insecureMode, "insecure", "k", false,
+		"Allow insecure server connections when using SSL")
 	return cmd
 }
 
 func main() {
-
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	logFileDirectory := filepath.Join(util.UserHomeDir(), constants.CELLERY_HOME, "logs")
 	logFilePath := filepath.Join(logFileDirectory, "cli.log")
 


### PR DESCRIPTION
## Purpose
> Add flag to use insecure server connections over SSL.

## Goals
> Add flag to use insecure server connections over SSL.

## Approach
> Add flag to use insecure server connections over SSL. Error handling in credentials readers had been improved as well.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A