### PR TITLE
Update error message of cellery describe command

### DIFF
--- a/components/cli/pkg/kubectl/cmd.go
+++ b/components/cli/pkg/kubectl/cmd.go
@@ -116,7 +116,7 @@ func printCommandOutput(cmd *exec.Cmd) (string, error) {
 	stderrScanner := bufio.NewScanner(stderrReader)
 	go func() {
 		for stderrScanner.Scan() {
-			output += stdoutScanner.Text()
+			output += stderrScanner.Text()
 		}
 	}()
 	err := cmd.Start()


### PR DESCRIPTION
Error message of CLI describe command was updated when describing a cell instance that does not exist.