### PR TITLE
Fix bug in cellery run where the registry is not honored

### DIFF
--- a/components/cli/pkg/commands/run.go
+++ b/components/cli/pkg/commands/run.go
@@ -1020,7 +1020,6 @@ func ExtractImage(cellImage *util.CellImage, spinner *util.Spinner) (string, err
 	repoLocation := filepath.Join(util.UserHomeDir(), constants.CELLERY_HOME, "repo", cellImage.Organization,
 		cellImage.ImageName, cellImage.ImageVersion)
 	zipLocation := filepath.Join(repoLocation, cellImage.ImageName+constants.CELL_IMAGE_EXT)
-	cellImageTag := cellImage.Organization + "/" + cellImage.ImageName + ":" + cellImage.ImageVersion
 
 	// Pull image if not exist
 	imageExists, err := util.FileExists(zipLocation)
@@ -1031,6 +1030,8 @@ func ExtractImage(cellImage *util.CellImage, spinner *util.Spinner) (string, err
 		if spinner != nil {
 			spinner.Pause()
 		}
+		cellImageTag := cellImage.Registry + "/" + cellImage.Organization + "/" + cellImage.ImageName +
+			":" + cellImage.ImageVersion
 		RunPull(cellImageTag, true, "", "")
 		fmt.Println()
 		if spinner != nil {


### PR DESCRIPTION
## Purpose
> Fix bug in cellery run where the registry is not honored

## Goals
> Fix bug in cellery run where the registry is not honored

## Approach
> Fix bug in cellery run where the registry is not honored

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A