### PR TITLE
supporting 'TargetAverageValue' in resource metrics

### DIFF
--- a/components/cli/pkg/commands/export_autoscale_policy.go
+++ b/components/cli/pkg/commands/export_autoscale_policy.go
@@ -175,6 +175,7 @@ func getMetricsFromPolicySpec(policySpec *kubectl.AutoscalePolicySpec) []policie
 			Resource: policies.Resource{
 				Name:                     metric.Resource.Name,
 				TargetAverageUtilization: metric.Resource.TargetAverageUtilization,
+				TargetAverageValue:       metric.Resource.TargetAverageValue,
 			},
 		}
 		specMetrics = append(specMetrics, specMetric)

--- a/components/cli/pkg/kubectl/structs.go
+++ b/components/cli/pkg/kubectl/structs.go
@@ -263,5 +263,6 @@ type ScaleTargetRef struct {
 
 type Resource struct {
 	Name                     string `json:"name"`
-	TargetAverageUtilization int    `json:"targetAverageUtilization"`
+	TargetAverageUtilization int    `json:"targetAverageUtilization,omitempty"`
+	TargetAverageValue       string `json:"targetAverageValue,omitempty"`
 }

--- a/components/cli/pkg/policies/policy_def.go
+++ b/components/cli/pkg/policies/policy_def.go
@@ -49,9 +49,6 @@ type Metric struct {
 
 type Resource struct {
 	Name                     string `json:"name"`
-	TargetAverageUtilization int    `json:"targetAverageUtilization"`
-}
-
-type Cpu struct {
-	TargetAverageUtilization int `json:"targetAverageUtilization"`
+	TargetAverageUtilization int    `json:"targetAverageUtilization,omitempty"`
+	TargetAverageValue       string `json:"targetAverageValue,omitempty"`
 }


### PR DESCRIPTION
## Purpose
> Support `TargetAverageValue` in CPU and Memory metrics for autoscaling. 