### PR TITLE
Update setup modify inline command flags

### DIFF
--- a/components/cli/cmd/cellery/setup_modify.go
+++ b/components/cli/cmd/cellery/setup_modify.go
@@ -19,27 +19,128 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	"github.com/cellery-io/sdk/components/cli/pkg/runtime"
+	"github.com/cellery-io/sdk/components/cli/pkg/util"
 
 	"github.com/cellery-io/sdk/components/cli/pkg/commands"
 )
 
+var apimEnabled = false
+var observabilityEnabled = false
+var scaleToZeroEnabled = false
+var hpaEnabled = false
+var apimgtChange = runtime.NoChange
+var observabilityChange = runtime.NoChange
+var scaleToZeroChange = runtime.NoChange
+var hpaChange = runtime.NoChange
+
 func newSetupModifyCommand() *cobra.Command {
-	var apimgt = false
-	var observability = false
-	var knative = false
-	var hpa = false
+	var apimgt = ""
+	var observability = ""
+	var scaleToZero = ""
+	var hpa = ""
 	cmd := &cobra.Command{
 		Use:   "modify <command>",
 		Short: "Modify Cellery runtime",
-		Run: func(cmd *cobra.Command, args []string) {
-			commands.RunSetupModify(commands.ConvertToSelection(apimgt), commands.ConvertToSelection(observability),
-				commands.ConvertToSelection(knative), commands.ConvertToSelection(hpa))
+		Args:  cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			invalidInputMessage := "invalid input for"
+			acceptedValuesMessage := "expected values are enable or disable"
+			if !isValidInput(apimgt) {
+				return fmt.Errorf("%s apim: %s. %s", invalidInputMessage, apimgt, acceptedValuesMessage)
+			}
+			if !isValidInput(observability) {
+				return fmt.Errorf("%s observability: %s. %s", invalidInputMessage, observability, acceptedValuesMessage)
+			}
+			if !isValidInput(scaleToZero) {
+				return fmt.Errorf("%s scale-to-zero: %s. %s", invalidInputMessage, scaleToZero, acceptedValuesMessage)
+			}
+			if !isValidInput(hpa) {
+				return fmt.Errorf("%s hpa: %s. %s", invalidInputMessage, hpa, acceptedValuesMessage)
+			}
+			return nil
 		},
+		Run: func(cmd *cobra.Command, args []string) {
+			apimgtChange = convertToSelection(apimgt)
+			observabilityChange = convertToSelection(observability)
+			scaleToZeroChange = convertToSelection(scaleToZero)
+			hpaChange = convertToSelection(hpa)
+			// Check the user inputs against the current runtime
+			validateRuntime()
+			commands.RunSetupModify(apimgtChange, observabilityChange, scaleToZeroChange, hpaChange)
+		},
+		Example: "  cellery setup modify --apim=enable --observability=disable",
 	}
-	cmd.Flags().BoolVar(&apimgt, "apimgt", false, "enable API Management in the runtime")
-	cmd.Flags().BoolVar(&observability, "observability", false, "enable Observability in the runtime")
-	cmd.Flags().BoolVar(&knative, "scale-to-zero", false, "enable scale to zero in the runtime")
-	cmd.Flags().BoolVar(&hpa, "hpa", false, "enable horizontal pod auto scalar in the runtime")
+	cmd.Flags().StringVar(&apimgt, "apim", "", "enable or disable API Management in the runtime")
+	cmd.Flags().StringVar(&observability, "observability", "", "enable or disable observability in the runtime")
+	cmd.Flags().StringVar(&scaleToZero, "scale-to-zero", "", "enable or disable scale to zero in the runtime")
+	cmd.Flags().StringVar(&hpa, "hpa", "", "enable or disable hpa in the runtime")
 	return cmd
+}
+
+func convertToSelection(change string) runtime.Selection {
+	if change == "enable" {
+		return runtime.Enable
+	} else if change == "disable" {
+		return runtime.Disable
+	}
+	return runtime.NoChange
+}
+
+func validateRuntime() {
+	var err error
+	// If user's desired apim change already exists in the runtime do not change apim behavior
+	if apimgtChange != runtime.NoChange {
+		apimEnabled, err = runtime.IsApimEnabled()
+		if err != nil {
+			util.ExitWithErrorMessage("Failed to set flag for apim", err)
+		}
+		if (apimEnabled && apimgtChange == runtime.Enable) || (!apimEnabled && apimgtChange == runtime.Disable) {
+			apimgtChange = runtime.NoChange
+		}
+	}
+	// If user's desired observability change already exists in the runtime do not change observability behavior
+	if observabilityChange != runtime.NoChange {
+		observabilityEnabled, err = runtime.IsObservabilityEnabled()
+		if err != nil {
+			util.ExitWithErrorMessage("Failed to set flag for observability", err)
+		}
+		if (observabilityEnabled && observabilityChange == runtime.Enable) || (!observabilityEnabled &&
+			observabilityChange == runtime.Disable) {
+			observabilityChange = runtime.NoChange
+		}
+	}
+	// If user's desired scale to zero change already exists in the runtime do not change scale to zero behavior
+	if scaleToZeroChange != runtime.NoChange {
+		scaleToZeroEnabled, err = runtime.IsKnativeEnabled()
+		if err != nil {
+			util.ExitWithErrorMessage("Failed to set flag for scale to zero", err)
+		}
+		if (scaleToZeroEnabled && scaleToZeroChange == runtime.Enable) || (!scaleToZeroEnabled &&
+			scaleToZeroChange == runtime.Disable) {
+			scaleToZeroChange = runtime.NoChange
+		}
+	}
+	// If user's desired hpa change already exists in the runtime do not change hpa behavior
+	if hpaChange != runtime.NoChange {
+		hpaEnabled, err = runtime.IsHpaEnabled()
+		if err != nil {
+			util.ExitWithErrorMessage("Failed to set flag for hpa", err)
+		}
+		if (hpaEnabled && hpaChange == runtime.Enable) || (!hpaEnabled &&
+			hpaChange == runtime.Disable) {
+			hpaChange = runtime.NoChange
+		}
+	}
+}
+
+func isValidInput(change string) bool {
+	if change == "enable" || change == "disable" || change == "" {
+		return true
+	}
+	return false
 }

--- a/components/cli/pkg/commands/setup_modify.go
+++ b/components/cli/pkg/commands/setup_modify.go
@@ -35,9 +35,9 @@ type changedComponent struct {
 }
 
 var apim = "API Manager"
-var autoscaling = "Autoscaling"
+var autoscaling = "Autoscaler"
 var knative = "Scale-to-Zero"
-var hpa = "Horizontal Pod Autoscalar"
+var hpa = "Horizontal Pod Autoscaler"
 var observability = "Observability"
 var apimEnabled = false
 var observabilityEnabled = false
@@ -62,13 +62,6 @@ func RunSetupModify(addApimGlobalGateway, addObservability, knative, hpa runtime
 		util.ExitWithErrorMessage("Error while checking hpa status", err)
 	}
 	util.WaitForRuntime(knativeEnabled, hpaEnabled)
-}
-
-func ConvertToSelection(enable bool) runtime.Selection {
-	if enable {
-		return runtime.Enable
-	}
-	return runtime.Disable
 }
 
 func modifyRuntime() {


### PR DESCRIPTION
* Previously to enable a component user has to explicitly give the flag for that component. Not providing the flag would disable the component.
* A third option was added to keep the component unchanged by not providing the flag.
* To enable or disable apim user has to give the flag apim=enable|disable