### PR TITLE
Update hpa flag to be unchanged when runtime is gcp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ install-lang:
 .PHONY: install-cli
 install-cli:
 	go build -o ${GO_BUILD_DIRECTORY}/cellery -ldflags "$(GO_LDFLAGS)" -x ./components/cli/cmd/cellery; \
-    cp ${GO_BUILD_DIRECTORY}/cellery /usr/local/bin; \
+    sudo cp ${GO_BUILD_DIRECTORY}/cellery /usr/local/bin; \
 
 .PHONY: copy-k8s-artefacts
 copy-k8s-artefacts:

--- a/components/cli/cmd/cellery/setup_modify.go
+++ b/components/cli/cmd/cellery/setup_modify.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -47,6 +48,12 @@ func newSetupModifyCommand() *cobra.Command {
 		Short: "Modify Cellery runtime",
 		Args:  cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if runtime.IsGcpRuntime() {
+				if strings.TrimSpace(hpa) != "" {
+					fmt.Printf("HPA cannot be changed in gcp runtime")
+					hpa = ""
+				}
+			}
 			invalidInputMessage := "invalid input for"
 			acceptedValuesMessage := "expected values are enable or disable"
 			if !isValidInput(apimgt) {
@@ -77,10 +84,7 @@ func newSetupModifyCommand() *cobra.Command {
 	cmd.Flags().StringVar(&apimgt, "apim", "", "enable or disable API Management in the runtime")
 	cmd.Flags().StringVar(&observability, "observability", "", "enable or disable observability in the runtime")
 	cmd.Flags().StringVar(&scaleToZero, "scale-to-zero", "", "enable or disable scale to zero in the runtime")
-	if !runtime.IsGcpRuntime() {
-		// Metric server is included by default in gcp, therefore hpa flag will not be available on a gcp cluster
-		cmd.Flags().StringVar(&hpa, "hpa", "", "enable or disable hpa in the runtime")
-	}
+	cmd.Flags().StringVar(&hpa, "hpa", "", "enable or disable hpa in the runtime")
 	return cmd
 }
 


### PR DESCRIPTION
If the user give hpa flag when running on gcp cluster, an error would be prompted.