### PR TITLE
Add cli command to terminate multiple instances

### DIFF
--- a/components/cli/cmd/cellery/terminate.go
+++ b/components/cli/cmd/cellery/terminate.go
@@ -19,35 +19,33 @@
 package main
 
 import (
-	"fmt"
-	"regexp"
-
 	"github.com/spf13/cobra"
 
 	"github.com/cellery-io/sdk/components/cli/pkg/commands"
-	"github.com/cellery-io/sdk/components/cli/pkg/constants"
 )
 
 func newTerminateCommand() *cobra.Command {
+	var terminateAll = false
 	cmd := &cobra.Command{
-		Use:     "terminate <instance-name>",
-		Short:   "Terminate a running cell instance",
+		Use:     "terminate <instance1> <instance2> <instance-3>",
+		Short:   "Terminate running cell instances",
 		Aliases: []string{"term"},
 		Args: func(cmd *cobra.Command, args []string) error {
-			err := cobra.ExactArgs(1)(cmd, args)
-			if err != nil {
-				return err
-			}
-			isCellValid, err := regexp.MatchString(fmt.Sprintf("^%s$", constants.CELLERY_ID_PATTERN), args[0])
-			if err != nil || !isCellValid {
-				return fmt.Errorf("expects a valid cell name, received %s", args[0])
+			if !terminateAll {
+				err := cobra.MinimumNArgs(1)(cmd, args)
+				if err != nil {
+					return err
+				}
 			}
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			commands.RunTerminate(args[0])
+			commands.RunTerminate(args, terminateAll)
 		},
-		Example: "  cellery terminate employee",
+		Example: "  cellery terminate employee\n" +
+			"  cellery terminate pet-fe pet-be\n" +
+			"  cellery terminate --all",
 	}
+	cmd.Flags().BoolVar(&terminateAll, "all", false, "Delete all cell instances")
 	return cmd
 }

--- a/components/cli/pkg/runtime/runtime.go
+++ b/components/cli/pkg/runtime/runtime.go
@@ -356,3 +356,15 @@ func IsGcpRuntime() bool {
 	}
 	return false
 }
+
+func GetInstancesNames() ([]string, error) {
+	var instances []string
+	runningInstances, err := kubectl.GetCells()
+	if err != nil {
+		return nil, err
+	}
+	for _, runningInstance := range runningInstances.Items {
+		instances = append(instances, runningInstance.CellMetaData.Name)
+	}
+	return instances, nil
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -231,15 +231,17 @@ Ex:
 
 #### Cellery Terminate
 
-Terminate the running cell instance within cell runtime.
+Terminate running cell instances within cell runtime.
 
 ###### Parameters:
 
-* _cell instance name: Name of the instance running in the cellery system_
+* _cell instance names: Names of the instances running in the cellery system_
 
 Ex: 
  ```
-   cellery terminate my-cell-inst
+   cellery terminate employee
+   cellery terminate pet-fe pet-be
+   cellery terminate --all
  ```
  
  [Back to Command List](#cellery-cli-commands)


### PR DESCRIPTION
* Currently there is only option to terminate one instance at a time. Modified cellery terminate command to have the capability to terminate multiple/all instances at once from the runtime.
* Updated the docs with the command changes.

Resolves https://github.com/wso2-cellery/sdk/issues/329