### PR TITLE
Minor improvement to cellery pull warning message printed in version mismatch

### DIFF
--- a/components/cli/pkg/commands/pull.go
+++ b/components/cli/pkg/commands/pull.go
@@ -232,7 +232,7 @@ func pullImage(parsedCellImage *util.CellImage, username string, password string
 		}
 		// TODO : Add a proper validation based on major, minor, patch, version before stable release
 		if metadata.BuildCelleryVersion != "" && metadata.BuildCelleryVersion != version.BuildVersion() {
-			fmt.Printf("\r\x1b[2K%s Pulled image version (%s) and Cellery installation version (%s) "+
+			fmt.Printf("\r\x1b[2K%s Pulled cell image's build version (%s) and Cellery installation version (%s) "+
 				"do not match. The image %s/%s:%s may not work properly with this installation.\n",
 				util.YellowBold("\U000026A0"), util.Bold(metadata.BuildCelleryVersion), version.BuildVersion(),
 				parsedCellImage.Organization, parsedCellImage.ImageName, parsedCellImage.ImageVersion)


### PR DESCRIPTION
## Purpose
> Minor improvement to cellery pull warning message printed in version mismatch

## Goals
> Minor improvement to cellery pull warning message printed in version mismatch

## Approach
> Minor improvement to cellery pull warning message printed in version mismatch

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A