### PR TITLE
Add validation to  setup status command to check if runtime is gcp

### DIFF
--- a/components/cli/pkg/runtime/hpa.go
+++ b/components/cli/pkg/runtime/hpa.go
@@ -47,8 +47,13 @@ func deleteHpa(artifactsPath string) error {
 }
 
 func IsHpaEnabled() (bool, error) {
+	var err error
 	enabled := true
-	_, err := kubectl.GetDeployment("kube-system", "metrics-server")
+	if IsGcpRuntime() {
+		_, err = kubectl.GetDeployment("kube-system", "metrics-server-v0.3.1")
+	} else {
+		_, err = kubectl.GetDeployment("kube-system", "metrics-server")
+	}
 	if err != nil {
 		if strings.Contains(err.Error(), "No resources found") ||
 			strings.Contains(err.Error(), "not found") {


### PR DESCRIPTION
* In gcp setup kubectl client version is v1.12. Therefore name of metrics-server deployment is "metrics-server-v0.3.1" and not "metrics-server".
* Therefor `cellery setup status` command gave an invalid status for hpa.  