### PR TITLE
Remove wait for metrics server when modifying gcp cluster

### DIFF
--- a/components/cli/pkg/commands/setup_modify.go
+++ b/components/cli/pkg/commands/setup_modify.go
@@ -61,6 +61,10 @@ func RunSetupModify(addApimGlobalGateway, addObservability, knative, hpa runtime
 	if err != nil {
 		util.ExitWithErrorMessage("Error while checking hpa status", err)
 	}
+	isGcpRuntime := runtime.IsGcpRuntime()
+	if isGcpRuntime {
+		hpaEnabled = false
+	}
 	util.WaitForRuntime(knativeEnabled, hpaEnabled)
 }
 


### PR DESCRIPTION
* Since for gcp setup metric server is installed by default there is no need to wait for metric server when modifying runtime.