### PR TITLE
initial fix for header aware routing

### DIFF
--- a/components/cli/cmd/cellery/route_traffic.go
+++ b/components/cli/cmd/cellery/route_traffic.go
@@ -39,12 +39,14 @@ func newRouteTrafficCommand() *cobra.Command {
 	var targetInstance string
 	var percentage int
 	var srcInstances []string
+	var sessionHeader string
 	cmd := &cobra.Command{
 		Use:   "route-traffic [--source|-s=<list_of_source_cell_instances>] --dependency|-d <dependency_instance_name> --target|-t <target instance name> [--percentage|-p <x>]",
 		Short: "route a percentage of the traffic to a cell instance",
 		Example: "cellery route-traffic --source hr-client-inst1 --dependency hr-inst-1 --target hr-inst-2 --percentage 20 \n" +
 			"cellery route-traffic --dependency hr-inst-1 --target hr-inst-2 --percentage 20 \n" +
-			"cellery route-traffic --dependency hr-inst-1 --target hr-inst-2",
+			"cellery route-traffic --dependency hr-inst-1 --target hr-inst-2 \n" +
+			"cellery route-traffic --dependency hr-inst-1 --target hr-inst-2 --percentage 25 --session-header x-sub-id",
 		Args: func(cmd *cobra.Command, args []string) error {
 			// validate
 			err := validateArguments(dependencyInstance, targetInstance)
@@ -73,7 +75,7 @@ func newRouteTrafficCommand() *cobra.Command {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			err := commands.RunRouteTrafficCommand(srcInstances, dependencyInstance, targetInstance, percentage)
+			err := commands.RunRouteTrafficCommand(srcInstances, dependencyInstance, targetInstance, percentage, sessionHeader)
 			if err != nil {
 				util.ExitWithErrorMessage(fmt.Sprintf("Unable to route traffic to the target instance: %s, percentage: %d", targetInstance, percentage), err)
 			}
@@ -83,6 +85,7 @@ func newRouteTrafficCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&dependencyInstance, "dependency", "d", "", "existing dependency instance name")
 	cmd.Flags().StringVarP(&targetInstance, "target", "t", "", "target instance to which the traffic should be re-routed")
 	cmd.Flags().StringVarP(&targetPercentage, "percentage", "p", "", "percentage to be switched to the target instance")
+	cmd.Flags().StringVarP(&sessionHeader, "session-header", "a", "", "header to be considered to route traffic to a single target instance")
 	return cmd
 }
 

--- a/components/cli/pkg/kubectl/structs.go
+++ b/components/cli/pkg/kubectl/structs.go
@@ -235,8 +235,15 @@ type HTTP struct {
 }
 
 type HTTPMatch struct {
-	Authority    Authority         `json:"authority"`
-	SourceLabels map[string]string `json:"sourceLabels"`
+	Authority    Authority               `json:"authority"`
+	SourceLabels map[string]string       `json:"sourceLabels"`
+	Headers      map[string]*StringMatch `json:"headers,omitempty"`
+}
+
+type StringMatch struct {
+	Exact  string `json:"exact,omitempty"`
+	Prefix string `json:"prefix,omitempty"`
+	Regex  string `json:"regex,omitempty"`
 }
 
 type Authority struct {


### PR DESCRIPTION
## Purpose
> The user is able to provide a session header with the route traffic command which will be used to route traffic to one of the instances in canary deployments. 