### PR TITLE
support basic session aware routing

### DIFF
--- a/components/cli/cmd/cellery/route_traffic.go
+++ b/components/cli/cmd/cellery/route_traffic.go
@@ -39,12 +39,14 @@ func newRouteTrafficCommand() *cobra.Command {
 	var targetInstance string
 	var percentage int
 	var srcInstances []string
+	var enableSessionAwareness bool
 	cmd := &cobra.Command{
 		Use:   "route-traffic [--source|-s=<list_of_source_cell_instances>] --dependency|-d <dependency_instance_name> --target|-t <target instance name> [--percentage|-p <x>]",
 		Short: "route a percentage of the traffic to a cell instance",
 		Example: "cellery route-traffic --source hr-client-inst1 --dependency hr-inst-1 --target hr-inst-2 --percentage 20 \n" +
 			"cellery route-traffic --dependency hr-inst-1 --target hr-inst-2 --percentage 20 \n" +
-			"cellery route-traffic --dependency hr-inst-1 --target hr-inst-2",
+			"cellery route-traffic --dependency hr-inst-1 --target hr-inst-2 \n" +
+			"cellery route-traffic --dependency hr-inst-1 --target hr-inst-2 --percentage 25 --enable-session-awareness",
 		Args: func(cmd *cobra.Command, args []string) error {
 			// validate
 			err := validateArguments(dependencyInstance, targetInstance)
@@ -73,7 +75,7 @@ func newRouteTrafficCommand() *cobra.Command {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			err := commands.RunRouteTrafficCommand(srcInstances, dependencyInstance, targetInstance, percentage)
+			err := commands.RunRouteTrafficCommand(srcInstances, dependencyInstance, targetInstance, percentage, enableSessionAwareness)
 			if err != nil {
 				util.ExitWithErrorMessage(fmt.Sprintf("Unable to route traffic to the target instance: %s, percentage: %d", targetInstance, percentage), err)
 			}
@@ -83,6 +85,7 @@ func newRouteTrafficCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&dependencyInstance, "dependency", "d", "", "existing dependency instance name")
 	cmd.Flags().StringVarP(&targetInstance, "target", "t", "", "target instance to which the traffic should be re-routed")
 	cmd.Flags().StringVarP(&targetPercentage, "percentage", "p", "", "percentage to be switched to the target instance")
+	cmd.Flags().BoolVarP(&enableSessionAwareness, "enable-session-awareness", "a", false, "flag to enable session awareness based on user name")
 	return cmd
 }
 

--- a/components/cli/pkg/kubectl/structs.go
+++ b/components/cli/pkg/kubectl/structs.go
@@ -235,8 +235,15 @@ type HTTP struct {
 }
 
 type HTTPMatch struct {
-	Authority    Authority         `json:"authority"`
-	SourceLabels map[string]string `json:"sourceLabels"`
+	Authority    Authority               `json:"authority"`
+	SourceLabels map[string]string       `json:"sourceLabels"`
+	Headers      map[string]*StringMatch `json:"headers,omitempty"`
+}
+
+type StringMatch struct {
+	Exact  string `json:"exact,omitempty"`
+	Prefix string `json:"prefix,omitempty"`
+	Regex  string `json:"regex,omitempty"`
 }
 
 type Authority struct {

--- a/docs/cell-update-and-adv-deployment.md
+++ b/docs/cell-update-and-adv-deployment.md
@@ -69,6 +69,8 @@ $ cellery route-traffic pet-be -p pet-be-v2=100
 ```
 cellery terminate pet-be
 ```
+- Additionally, you can use the flag `--enable-session-awareness` to enable session aware routing based on the user name. 
+An instance will be selected and will be propagated via the header `x-instance-id`. Its the cell component's responsibility to forward this header if this option is to be used.
 
 #### Note:
 The above commands will apply to all cell instances which has a dependency on `pet-be`. If required, route-traffic command can be applied to only a selected set of instances

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -371,11 +371,13 @@ This is used to direct a percentage of traffic originating from one cell instanc
 * _-s, --source: The source instance which is generating traffic for the dependency instance specified in the Parameters above. 
 If this is not given all instances which are currently depending on the provided dependency instance will be considered._
 * _-p, --percentage: The percentage of traffic to be routed to the target instance. If not specified, this will be considered to be 100%._
+* _-a, --enable-session-awareness: Flag to enable session aware routing based on user name. An instance will be selected and will be propagated via the header `x-instance-id`. Its the cell component's responsibility to forward this header if this option is to be used._
 
 Ex:
  ```
    cellery route-traffic --source hr-client-inst1 --dependency hr-inst-1 --target hr-inst-2 --percentage 20 
    cellery route-traffic --dependency hr-inst-1 --target hr-inst-2 --percentage 20
+   cellery route-traffic --dependency hr-inst-1 --target hr-inst-2 --percentage 20 --enable-session-awareness
    cellery route-traffic --dependency hr-inst-1 --target hr-inst-2
  ```
 


### PR DESCRIPTION
## Purpose
> Supports basic session aware routing by picking one of the instances based on user name. This will be propagated via `x-instance-id`.