### PR TITLE
Add minor changes to the metadata.json

### DIFF
--- a/components/cellery-component-test/src/test/java/org/cellery/components/test/scenarios/employee/EmployeeTest.java
+++ b/components/cellery-component-test/src/test/java/org/cellery/components/test/scenarios/employee/EmployeeTest.java
@@ -222,7 +222,6 @@ public class EmployeeTest {
                     Assert.assertEquals(employeeComponent.get("dockerImage").getAsString(),
                             "wso2cellery/sampleapp-employee:0.3.0");
                     Assert.assertFalse(employeeComponent.get("isDockerPushRequired").getAsBoolean());
-                    Assert.assertTrue(employeeComponent.get("exposed").getAsBoolean());
 
                     JsonObject labels = employeeComponent.getAsJsonObject("labels");
                     Assert.assertEquals(labels.size(), 1);
@@ -240,7 +239,6 @@ public class EmployeeTest {
                     Assert.assertEquals(salaryComponent.get("dockerImage").getAsString(),
                             "wso2cellery/sampleapp-salary:0.3.0");
                     Assert.assertFalse(salaryComponent.get("isDockerPushRequired").getAsBoolean());
-                    Assert.assertTrue(salaryComponent.get("exposed").getAsBoolean());
 
                     JsonObject labels = salaryComponent.getAsJsonObject("labels");
                     Assert.assertEquals(labels.size(), 2);

--- a/components/cli/pkg/commands/build.go
+++ b/components/cli/pkg/commands/build.go
@@ -359,8 +359,8 @@ func generateMetaData(cellImage *image.CellImage, targetDir string, spinner *uti
 			}
 		}
 		if !hasTCPType {
-			metadata.Components[tcpApi.Backend].IngressTypes = append(metadata.Components[tcpApi.Backend].IngressTypes,
-				"TCP")
+			metadata.Components[tcpApi.Backend].IngressTypes =
+				append(metadata.Components[tcpApi.Backend].IngressTypes, "TCP")
 		}
 	}
 	for _, httpApi := range k8sCell.CellSpec.GateWayTemplate.GatewaySpec.HttpApis {
@@ -373,8 +373,8 @@ func generateMetaData(cellImage *image.CellImage, targetDir string, spinner *uti
 				}
 			}
 			if !hasHttpType {
-				metadata.Components[httpApi.Backend].IngressTypes = append(metadata.Components[httpApi.Backend].IngressTypes,
-					ingressType)
+				metadata.Components[httpApi.Backend].IngressTypes =
+					append(metadata.Components[httpApi.Backend].IngressTypes, ingressType)
 			}
 		}
 		if k8sCell.CellSpec.GateWayTemplate.GatewaySpec.Host == "" {
@@ -392,8 +392,8 @@ func generateMetaData(cellImage *image.CellImage, targetDir string, spinner *uti
 			}
 		}
 		if !hasGrpcType {
-			metadata.Components[grpcApi.Backend].IngressTypes = append(metadata.Components[grpcApi.Backend].IngressTypes,
-				"GRPC")
+			metadata.Components[grpcApi.Backend].IngressTypes =
+				append(metadata.Components[grpcApi.Backend].IngressTypes, "GRPC")
 		}
 	}
 

--- a/components/cli/pkg/commands/build.go
+++ b/components/cli/pkg/commands/build.go
@@ -318,6 +318,7 @@ func generateMetaData(cellImage *image.CellImage, targetDir string, spinner *uti
 	}
 
 	metadata := &image.MetaData{
+		SchemaVersion: "0.1.0",
 		CellImageName: image.CellImageName{
 			Organization: cellImage.Organization,
 			Name:         cellImage.ImageName,

--- a/components/cli/pkg/image/structs.go
+++ b/components/cli/pkg/image/structs.go
@@ -107,6 +107,7 @@ type CellImageName struct {
 
 type MetaData struct {
 	CellImageName
+	SchemaVersion       string                        `json:"schemaVersion"`
 	Kind                string                        `json:"kind"`
 	Components          map[string]*ComponentMetaData `json:"components"`
 	BuildTimestamp      int64                         `json:"buildTimestamp"`

--- a/components/cli/pkg/image/structs.go
+++ b/components/cli/pkg/image/structs.go
@@ -121,7 +121,6 @@ type ComponentMetaData struct {
 	Labels               map[string]string      `json:"labels"`
 	IngressTypes         []string               `json:"ingressTypes"`
 	Dependencies         *ComponentDependencies `json:"dependencies"`
-	Exposed              bool                   `json:"exposed"`
 }
 
 type ComponentDependencies struct {

--- a/components/docs-view/resources/data/cell.js
+++ b/components/docs-view/resources/data/cell.js
@@ -61,8 +61,7 @@ window.__CELL_METADATA__ = {
                                     "components": [
                                         "salary"
                                     ]
-                                },
-                                "exposed": true
+                                }
                             },
                             "salary": {
                                 "dockerImage": "wso2cellery/sampleapp-salary:0.3.0",
@@ -77,8 +76,7 @@ window.__CELL_METADATA__ = {
                                 "dependencies": {
                                     "cells": {},
                                     "components": []
-                                },
-                                "exposed": true
+                                }
                             }
                         },
                         "buildTimestamp": 1565001781,
@@ -102,8 +100,7 @@ window.__CELL_METADATA__ = {
                                 "dependencies": {
                                     "cells": {},
                                     "components": []
-                                },
-                                "exposed": true
+                                }
                             }
                         },
                         "buildTimestamp": 1565001794,
@@ -113,8 +110,7 @@ window.__CELL_METADATA__ = {
                     }
                 },
                 "components": []
-            },
-            "exposed": true
+            }
         }
     },
     "buildTimestamp": 1565001804,

--- a/components/docs-view/resources/data/cell.js
+++ b/components/docs-view/resources/data/cell.js
@@ -27,6 +27,7 @@
 /* eslint no-underscore-dangle: ["off"] */
 
 window.__CELL_METADATA__ = {
+    "schemaVersion": "0.1.0",
     "org": "myorg",
     "name": "hr",
     "ver": "1.0.0",
@@ -42,6 +43,7 @@ window.__CELL_METADATA__ = {
             "dependencies": {
                 "cells": {
                     "employeeCellDep": {
+                        "schemaVersion": "0.1.0",
                         "org": "myorg",
                         "name": "employee",
                         "ver": "1.0.0",
@@ -85,6 +87,7 @@ window.__CELL_METADATA__ = {
                         "autoScalingRequired": false
                     },
                     "stockCellDep": {
+                        "schemaVersion": "0.1.0",
                         "org": "myorg",
                         "name": "stock",
                         "ver": "1.0.0",

--- a/components/docs-view/src/App.js
+++ b/components/docs-view/src/App.js
@@ -142,7 +142,7 @@ const App = ({data, classes}) => {
                             to: dependentComponent
                         });
                     });
-                    if (node.kind === Constants.Type.CELL && component.exposed) {
+                    if (node.kind === Constants.Type.CELL) {
                         nodeMetaInfo.componentDependencyLinks.push({
                             from: "gateway",
                             to: componentName


### PR DESCRIPTION
## Purpose
> Remove exposed field from metadata.json and add schema version

## Goals
> Remove exposed field from metadata.json and add schema version

## Approach
> Currently only the exposed ingress types are added to the ingressTypes field and only the exposed ingresses are required by other components of Cellery and Cellery Hub. Therefore this field is redundant. Therefore it was removed. The schema version was added to identify the exact metadata format in the future for handling the metadata in a backward compatible manner.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A