### PR TITLE
Fix bug in extracting ingress types in Composites from YAML for the metadata.json

### DIFF
--- a/components/cli/pkg/image/structs.go
+++ b/components/cli/pkg/image/structs.go
@@ -45,10 +45,15 @@ type CellSpec struct {
 
 type ComponentTemplate struct {
 	Metadata ComponentTemplateMetadata `json:"metadata"`
+	Spec     ComponentTemplateSpec     `json:"spec"`
 }
 
 type ComponentTemplateMetadata struct {
 	Name string `json:"name"`
+}
+
+type ComponentTemplateSpec struct {
+	Protocol string `json:"protocol"`
 }
 
 type CellStatus struct {


### PR DESCRIPTION
## Purpose
> Fix bug in extracting ingress types in Composites from YAML for the metadata.json

## Goals
> Fix bug in extracting ingress types in Composites from YAML for the metadata.json

## Approach
> Fix bug in extracting ingress types in Composites from YAML for the metadata.json

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A