### PR TITLE
Add GRPC TCP Ingress support to composite

### DIFF
--- a/components/cellery-component-test/src/test/java/org/cellery/components/test/scenarios/composite/HRCompositeTest.java
+++ b/components/cellery-component-test/src/test/java/org/cellery/components/test/scenarios/composite/HRCompositeTest.java
@@ -151,9 +151,9 @@ public class HRCompositeTest {
         Assert.assertEquals(runtimeComposite.getSpec().getServicesTemplates().get(0).getMetadata().getName(), "hr");
         final ServiceTemplateSpec spec = runtimeComposite.getSpec().getServicesTemplates().get(0).getSpec();
         Assert.assertEquals(spec.getContainer().getEnv().get(0).getName(), "stock_api_url");
-        Assert.assertEquals(spec.getContainer().getEnv().get(0).getValue(), "http://stock-inst--stock-service:8080");
+        Assert.assertEquals(spec.getContainer().getEnv().get(0).getValue(), "http://stock-inst--stock-service:80");
         Assert.assertEquals(spec.getContainer().getEnv().get(1).getName(), "employee_api_url");
-        Assert.assertEquals(spec.getContainer().getEnv().get(1).getValue(), "http://emp-inst--employee-service:8080");
+        Assert.assertEquals(spec.getContainer().getEnv().get(1).getValue(), "http://emp-inst--employee-service:80");
         Assert.assertEquals(spec.getContainer().getImage(), "wso2cellery/sampleapp-hr:0.3.0");
         Assert.assertEquals(spec.getContainer().getPorts().get(0).getContainerPort().intValue(), 8080);
         Assert.assertEquals(spec.getReplicas(), 1);

--- a/components/cellery-component-test/src/test/java/org/cellery/components/test/scenarios/composite/TCPTest.java
+++ b/components/cellery-component-test/src/test/java/org/cellery/components/test/scenarios/composite/TCPTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.cellery.components.test.scenarios.composite;
+
+import io.cellery.CelleryUtils;
+import io.cellery.models.Cell;
+import io.cellery.models.ServiceTemplateSpec;
+import org.ballerinax.kubernetes.exceptions.KubernetesPluginException;
+import org.ballerinax.kubernetes.utils.KubernetesUtils;
+import org.cellery.components.test.models.CellImageInfo;
+import org.cellery.components.test.utils.LangTestUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.cellery.components.test.utils.CelleryTestConstants.BAL;
+import static org.cellery.components.test.utils.CelleryTestConstants.CELLERY;
+import static org.cellery.components.test.utils.CelleryTestConstants.CELLERY_IMAGE_NAME;
+import static org.cellery.components.test.utils.CelleryTestConstants.CELLERY_IMAGE_ORG;
+import static org.cellery.components.test.utils.CelleryTestConstants.CELLERY_IMAGE_VERSION;
+import static org.cellery.components.test.utils.CelleryTestConstants.TARGET;
+import static org.cellery.components.test.utils.CelleryTestConstants.YAML;
+
+public class TCPTest {
+
+    private static final Path SAMPLE_DIR = Paths.get(System.getProperty("sample.dir"));
+    private static final Path SOURCE_DIR_PATH = SAMPLE_DIR.resolve("composite" + File.separator + "grpc-tcp");
+    private static final Path TARGET_PATH = SOURCE_DIR_PATH.resolve(TARGET);
+    private static final Path CELLERY_PATH = TARGET_PATH.resolve(CELLERY);
+    private Cell cell;
+    private CellImageInfo cellImageInfo = new CellImageInfo("myorg", "database", "1.0.0", "db-inst");
+
+    @Test(groups = "build")
+    public void compileCellBuild() throws IOException, InterruptedException {
+        Assert.assertEquals(LangTestUtils.compileCellBuildFunction(SOURCE_DIR_PATH, "grpc-tcp" + BAL, cellImageInfo),
+                0);
+        File artifactYaml = CELLERY_PATH.resolve(cellImageInfo.getName() + YAML).toFile();
+        Assert.assertTrue(artifactYaml.exists());
+        cell = CelleryUtils.readCellYaml(CELLERY_PATH.resolve(cellImageInfo.getName() + YAML).toString());
+    }
+
+    @Test(groups = "build")
+    public void validateBuildTimeCellAvailability() {
+        Assert.assertNotNull(cell);
+    }
+
+    @Test(groups = "build")
+    public void validateBuildTimeAPIVersion() {
+        Assert.assertEquals(cell.getApiVersion(), "mesh.cellery.io/v1alpha1");
+    }
+
+    @Test(groups = "build")
+    public void validateBuildTimeMetaData() {
+        Assert.assertEquals(cell.getMetadata().getName(), cellImageInfo.getName());
+        Assert.assertEquals(cell.getMetadata().getAnnotations().get(CELLERY_IMAGE_ORG), cellImageInfo.getOrg());
+        Assert.assertEquals(cell.getMetadata().getAnnotations().get(CELLERY_IMAGE_NAME), cellImageInfo.getName());
+        Assert.assertEquals(cell.getMetadata().getAnnotations().get(CELLERY_IMAGE_VERSION), cellImageInfo.getVer());
+    }
+
+    @Test(groups = "build")
+    public void validateBuildTimeServiceTemplates() {
+        Assert.assertEquals(cell.getSpec().getServicesTemplates().get(0).getMetadata().getName(), "mysql");
+        final ServiceTemplateSpec spec = cell.getSpec().getServicesTemplates().get(0).getSpec();
+        Assert.assertEquals(spec.getContainer().getEnv().get(0).getName(), "MYSQL_ROOT_PASSWORD");
+        Assert.assertEquals(spec.getContainer().getEnv().get(0).getValue(), "root");
+        Assert.assertEquals(spec.getContainer().getImage(), "mirage20/samples-productreview-mysql");
+        Assert.assertEquals(spec.getContainer().getPorts().get(0).getContainerPort().intValue(), 3306);
+        Assert.assertEquals(spec.getProtocol(), "TCP");
+        Assert.assertEquals(spec.getReplicas(), 1);
+        Assert.assertEquals(spec.getServicePort(), 3306);
+
+        Assert.assertEquals(cell.getSpec().getServicesTemplates().get(1).getMetadata().getName(), "grpc");
+        final ServiceTemplateSpec grpcCompSpec = cell.getSpec().getServicesTemplates().get(1).getSpec();
+        Assert.assertEquals(grpcCompSpec.getContainer().getImage(), "mirage20/samples-productreview-mysql");
+        Assert.assertEquals(grpcCompSpec.getContainer().getPorts().get(0).getContainerPort().intValue(), 4406);
+        Assert.assertEquals(grpcCompSpec.getProtocol(), "GRPC");
+        Assert.assertEquals(grpcCompSpec.getReplicas(), 1);
+        Assert.assertEquals(grpcCompSpec.getServicePort(), 4406);
+    }
+
+    @AfterClass
+    public void cleanUp() throws KubernetesPluginException {
+        KubernetesUtils.deleteDirectory(TARGET_PATH);
+    }
+}

--- a/components/cellery-component-test/src/test/resources/testng.xml
+++ b/components/cellery-component-test/src/test/resources/testng.xml
@@ -43,6 +43,7 @@
             <class name="org.cellery.components.test.scenarios.composite.StockCompositeTest"/>
             <class name="org.cellery.components.test.scenarios.composite.EmployeeCompositeTest"/>
             <class name="org.cellery.components.test.scenarios.composite.HRCompositeTest"/>
+            <class name="org.cellery.components.test.scenarios.composite.TCPTest"/>
         </classes>
     </test>
 </suite>

--- a/components/lang/src/main/ballerina/celleryio/cellery/natives.bal
+++ b/components/lang/src/main/ballerina/celleryio/cellery/natives.bal
@@ -275,6 +275,15 @@ function validateCell(CellImage image) {
         if (!(component["ingresses"] is ()) && component.ingresses.length() > 1) {
             error err = error("component: [" + component.name + "] has more than one ingress");
             panic err;
+        } else if (image.kind == "Composite") {
+            //TODO: Fix this when multiple ingress support is added.
+            var ingress = component.ingresses[component.ingresses.keys()[0]];
+            if(ingress is HttpApiIngress || ingress is WebIngress) {
+                string errMsg = "Invalid ingress type in component "+component.name + ". Composites doesn't support HttpApiIngress and WebIngress.";
+                error e = error(errMsg);
+                log:printError("Invalid ingress found ", err = e);
+                panic e;
+            }
         }
         if (!(component["scalingPolicy"] is ()) && (component.scalingPolicy is AutoScalingPolicy)) {
             AutoScalingPolicy policy = <AutoScalingPolicy> component.scalingPolicy;

--- a/components/lang/src/main/java/io/cellery/impl/CreateCellImage.java
+++ b/components/lang/src/main/java/io/cellery/impl/CreateCellImage.java
@@ -542,7 +542,11 @@ public class CreateCellImage extends BlockingNativeCallableUnit {
         if (image.isCompositeImage()) {
             image.getComponentNameToComponentMap().forEach((componentName, component) -> {
                 json.put(componentName + "_host", INSTANCE_NAME_PLACEHOLDER + "--" + componentName + "-service");
-                json.put(componentName + "_port", component.getContainerPort());
+                if (component.getApis().size() > 0) {
+                    json.put(componentName + "_port", DEFAULT_GATEWAY_PORT);
+                }
+                component.getTcpList().forEach(tcp -> json.put(componentName + "_tcp_port", tcp.getPort()));
+                component.getGrpcList().forEach(grpc -> json.put(componentName + "_grpc_port", grpc.getPort()));
             });
         } else {
             image.getComponentNameToComponentMap().forEach((componentName, component) -> {

--- a/test-cases/composite/grpc-tcp/grpc-tcp.bal
+++ b/test-cases/composite/grpc-tcp/grpc-tcp.bal
@@ -1,0 +1,53 @@
+//   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import ballerina/io;
+import celleryio/cellery;
+
+public function build(cellery:ImageName iName) returns error? {
+    //Build MySQL Cell
+    //MySQL Component
+    cellery:Component mysqlComponent = {
+        name: "mysql",
+        source: {
+            image: "mirage20/samples-productreview-mysql"
+        },
+        ingresses: {
+            mysqlIngress: <cellery:TCPIngress>{
+                backendPort: 3306,
+                gatewayPort: 31406
+            }
+        },
+        envVars: {
+            MYSQL_ROOT_PASSWORD: { value: "root" }
+        }
+    };
+
+    cellery:Component grpcComponent = {
+            name: "grpc",
+            source: {
+                image: "mirage20/samples-productreview-mysql"
+            },
+            ingresses: {
+                mysqlIngress: <cellery:GRPCIngress>{
+                    backendPort: 4406
+                }
+            }
+        };
+
+    cellery:Composite mysqlComposite = {
+        components: {
+            mysqlComp: mysqlComponent,
+            grpcComp: grpcComponent
+        }
+    };
+    return cellery:createImage(mysqlComposite, untaint iName);
+}


### PR DESCRIPTION
## Purpose
- Add GRPC TCP Ingress support to composite
- Add ingress type validations (Resolves https://github.com/wso2-cellery/sdk/issues/632)