### PR TITLE
Add mixer-adapter.yaml file path

### DIFF
--- a/components/cli/pkg/runtime/gcp/observability.go
+++ b/components/cli/pkg/runtime/gcp/observability.go
@@ -67,5 +67,6 @@ func buildObservabilityYamlPaths() []string {
 		filepath.Join(base, "portal", "observability-portal.yaml"),
 		filepath.Join(base, "prometheus", "k8s-metrics-prometheus.yaml"),
 		filepath.Join(base, "grafana", "k8s-metrics-grafana.yaml"),
+		filepath.Join(base, "mixer-adapter", "mixer-adapter.yaml"),
 	}
 }

--- a/components/cli/pkg/runtime/observability.go
+++ b/components/cli/pkg/runtime/observability.go
@@ -76,6 +76,7 @@ func buildObservabilityYamlPaths(artifactsPath string) []string {
 		filepath.Join(base, "portal", "observability-portal.yaml"),
 		filepath.Join(base, "prometheus", "k8s-metrics-prometheus.yaml"),
 		filepath.Join(base, "grafana", "k8s-metrics-grafana.yaml"),
+		filepath.Join(base, "mixer-adapter", "mixer-adapter.yaml"),
 	}
 }
 


### PR DESCRIPTION
## Purpose
> Deploy mixer adapter when observability is turned on

## Goals
> Add mixer-adapter.yaml file path