### PR TITLE
Remove namespace when applying and deleting observability yamls

### DIFF
--- a/components/cli/pkg/runtime/gcp/observability.go
+++ b/components/cli/pkg/runtime/gcp/observability.go
@@ -52,7 +52,7 @@ func buildObservabilityConfigMaps() []ConfigMap {
 
 func AddObservability() error {
 	for _, v := range buildObservabilityYamlPaths() {
-		err := kubectl.ApplyFileWithNamespace(v, "cellery-system")
+		err := kubectl.ApplyFile(v)
 		if err != nil {
 			return err
 		}

--- a/components/cli/pkg/runtime/observability.go
+++ b/components/cli/pkg/runtime/observability.go
@@ -28,7 +28,7 @@ import (
 
 func addObservability(artifactsPath string) error {
 	for _, v := range buildObservabilityYamlPaths(artifactsPath) {
-		err := kubectl.ApplyFileWithNamespace(v, "cellery-system")
+		err := kubectl.ApplyFile(v)
 		if err != nil {
 			return err
 		}
@@ -38,7 +38,7 @@ func addObservability(artifactsPath string) error {
 
 func deleteObservability(artifactsPath string) error {
 	for _, v := range buildObservabilityYamlPaths(artifactsPath) {
-		err := kubectl.DeleteFileWithNamespace(v, "cellery-system")
+		err := kubectl.DeleteFile(v)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Purpose
> To apply yamls without namespace flag since difference namespaces are used ( istio-namespace for mixer adapter )

## Approach
> Remove namespace when applying and deleting observability yamls