### PR TITLE
Fix #691 - Update Instance structs used in build to v1alpha2

### DIFF
--- a/components/cli/pkg/commands/list_components.go
+++ b/components/cli/pkg/commands/list_components.go
@@ -52,8 +52,8 @@ func getCellImageCompoents(cellImage string) []string {
 	if err != nil {
 		util.ExitWithErrorMessage("Error while reading cell image content", err)
 	}
-	for i := 0; i < len(cellImageContent.CellSpec.ComponentTemplates); i++ {
-		components = append(components, cellImageContent.CellSpec.ComponentTemplates[i].Metadata.Name)
+	for _, component := range cellImageContent.Spec.Components {
+		components = append(components, component.Metadata.Name)
 	}
 	return components
 }

--- a/components/cli/pkg/commands/list_ingresses.go
+++ b/components/cli/pkg/commands/list_ingresses.go
@@ -118,24 +118,23 @@ func displayCellImageApisTable(cellImageName string) {
 		util.ExitWithErrorMessage("Error while reading cell image content", err)
 	}
 	var tableData [][]string
-	for i := 0; i < len(cellImageContent.CellSpec.ComponentTemplates); i++ {
-		componentName := cellImageContent.CellSpec.ComponentTemplates[i].Metadata.Name
+	for _, component := range cellImageContent.Spec.Components {
+		componentName := component.Metadata.Name
 		// Iterate HTTP and Web ingresses
-		for j := 0; j < len(cellImageContent.CellSpec.GateWayTemplate.GatewaySpec.HttpApis); j++ {
-			ingress := cellImageContent.CellSpec.GateWayTemplate.GatewaySpec.HttpApis[j]
-			backend := ingress.Backend
-			var ingressType = "web"
+		for _, ingress := range cellImageContent.Spec.Gateway.Spec.Ingress.HTTP {
+			backend := ingress.Destination.Host
 			if componentName == backend {
 				var ingressData []string
 				ingressData = append(ingressData, componentName)
 
-				if len(cellImageContent.CellSpec.GateWayTemplate.GatewaySpec.Host) == 0 {
-					ingressType = "HTTP"
+				var ingressType = "web"
+				if len(cellImageContent.Spec.Gateway.Spec.Ingress.Extensions.ClusterIngress.Host) == 0 {
+					ingressType = "http"
 				}
 				ingressData = append(ingressData, ingressType)
 				ingressData = append(ingressData, ingress.Context)
-				ingressData = append(ingressData, strconv.Itoa(80))
-				if ingress.Global {
+				ingressData = append(ingressData, strconv.Itoa(ingress.Port))
+				if ingressType == "web" || ingress.Global {
 					ingressData = append(ingressData, "True")
 				} else {
 					ingressData = append(ingressData, "False")
@@ -144,29 +143,27 @@ func displayCellImageApisTable(cellImageName string) {
 			}
 		}
 		// Iterate TCP ingresses
-		for j := 0; j < len(cellImageContent.CellSpec.GateWayTemplate.GatewaySpec.TcpApis); j++ {
-			ingress := cellImageContent.CellSpec.GateWayTemplate.GatewaySpec.TcpApis[j]
-			backend := ingress.Backend
+		for _, ingress := range cellImageContent.Spec.Gateway.Spec.Ingress.TCP {
+			backend := ingress.Destination.Host
 			if componentName == backend {
 				var ingressData []string
 				ingressData = append(ingressData, componentName)
 				ingressData = append(ingressData, "tcp")
 				ingressData = append(ingressData, "N/A")
-				ingressData = append(ingressData, strconv.Itoa(8080))
+				ingressData = append(ingressData, strconv.Itoa(ingress.Port))
 				ingressData = append(ingressData, "False")
 				tableData = append(tableData, ingressData)
 			}
 		}
 		// Iterate GRPC ingresses
-		for j := 0; j < len(cellImageContent.CellSpec.GateWayTemplate.GatewaySpec.TcpApis); j++ {
-			ingress := cellImageContent.CellSpec.GateWayTemplate.GatewaySpec.TcpApis[j]
-			backend := ingress.Backend
+		for _, ingress := range cellImageContent.Spec.Gateway.Spec.Ingress.GRPC {
+			backend := ingress.Destination.Host
 			if componentName == backend {
 				var ingressData []string
 				ingressData = append(ingressData, componentName)
 				ingressData = append(ingressData, "grpc")
 				ingressData = append(ingressData, "N/A")
-				ingressData = append(ingressData, strconv.Itoa(3550))
+				ingressData = append(ingressData, strconv.Itoa(ingress.Port))
 				ingressData = append(ingressData, "False")
 				tableData = append(tableData, ingressData)
 			}

--- a/components/cli/pkg/image/structs.go
+++ b/components/cli/pkg/image/structs.go
@@ -20,10 +20,10 @@
 package image
 
 type Cell struct {
-	Kind         string       `json:"kind"`
-	CellMetaData CellMetaData `json:"metadata"`
-	CellSpec     CellSpec     `json:"spec"`
-	CellStatus   CellStatus   `json:"status"`
+	Kind     string       `json:"kind"`
+	MetaData CellMetaData `json:"metadata"`
+	Spec     CellSpec     `json:"spec"`
+	Status   CellStatus   `json:"status"`
 }
 
 type CellMetaData struct {
@@ -39,63 +39,75 @@ type CellAnnotations struct {
 }
 
 type CellSpec struct {
-	ComponentTemplates []ComponentTemplate `json:"servicesTemplates"`
-	GateWayTemplate    Gateway             `json:"gatewayTemplate"`
+	Components []Component `json:"components"`
+	Gateway    Gateway     `json:"gateway,omitempty"`
 }
 
-type ComponentTemplate struct {
-	Metadata ComponentTemplateMetadata `json:"metadata"`
-	Spec     ComponentTemplateSpec     `json:"spec"`
+type Component struct {
+	Metadata ComponentMetadata `json:"metadata"`
+	Spec     ComponentSpec     `json:"spec"`
 }
 
-type ComponentTemplateMetadata struct {
+type ComponentMetadata struct {
 	Name string `json:"name"`
 }
 
-type ComponentTemplateSpec struct {
+type ComponentSpec struct {
+	Ports []ComponentPort `json:"ports"`
+}
+
+type ComponentPort struct {
 	Protocol string `json:"protocol"`
 }
 
-type CellStatus struct {
-	Status       string `json:"status"`
-	Gateway      string `json:"gatewayHostname"`
-	ServiceCount int    `json:"serviceCount"`
-}
-
 type Gateway struct {
-	GatewaySpec GatewaySpec `json:"spec"`
+	Spec GatewaySpec `json:"spec"`
 }
 
 type GatewaySpec struct {
-	HttpApis []GatewayHttpApi `json:"http"`
-	TcpApis  []GatewayTcpApi  `json:"tcp"`
-	GrpcApis []GatewayGrpcApi `json:"grpc"`
-	Host     string           `json:"host"`
+	Ingress Ingress `json:"ingress"`
 }
 
-type GatewayHttpApi struct {
-	Backend      string              `json:"backend"`
-	Context      string              `json:"context"`
-	Definitions  []GatewayDefinition `json:"definitions"`
-	Global       bool                `json:"global"`
-	Authenticate string              `json:"authenticate"`
+type Ingress struct {
+	Extensions Extensions    `json:"extensions"`
+	HTTP       []HttpIngress `json:"http"`
+	GRPC       []GrpcIngress `json:"grpc"`
+	TCP        []TcpIngress  `json:"tcp"`
 }
 
-type GatewayTcpApi struct {
-	Backend     string `json:"backendHost"`
-	BackendPort uint16 `json:"backendPort"`
-	Port        uint16 `json:"port"`
+type Extensions struct {
+	ClusterIngress ClusterIngress `json:"clusterIngress"`
 }
 
-type GatewayGrpcApi struct {
-	Backend     string `json:"backendHost"`
-	BackendPort uint16 `json:"backendPort"`
-	Port        uint16 `json:"port"`
+type ClusterIngress struct {
+	Host string `json:"host"`
 }
 
-type GatewayDefinition struct {
-	Method string `json:"method"`
-	Path   string `json:"path"`
+type HttpIngress struct {
+	Context     string      `json:"context"`
+	Global      bool        `json:"global"`
+	Port        int         `json:"port"`
+	Destination Destination `json:"destination"`
+}
+
+type GrpcIngress struct {
+	Port        int         `json:"port"`
+	Destination Destination `json:"destination"`
+}
+
+type TcpIngress struct {
+	Port        int         `json:"port"`
+	Destination Destination `json:"destination"`
+}
+
+type Destination struct {
+	Host string `json:"host"`
+}
+
+type CellStatus struct {
+	Status         string `json:"status"`
+	Gateway        string `json:"gatewayServiceName"`
+	ComponentCount int    `json:"componentCount"`
 }
 
 type CellImage struct {


### PR DESCRIPTION
## Purpose
> Update Instance structs used in build to v1alpha2

## Goals
> Update Instance structs used in build to v1alpha2

## Approach
> Update Instance structs used in build to v1alpha2

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A