### PR TITLE
Add cellery home directory structure creation to cellery root command

### DIFF
--- a/components/cli/cmd/cellery/cellery.go
+++ b/components/cli/cmd/cellery/cellery.go
@@ -79,6 +79,7 @@ func newCliCommand() *cobra.Command {
 }
 
 func main() {
+	util.CreateCelleryDirStructure()
 	logFileDirectory := filepath.Join(util.UserHomeDir(), constants.CELLERY_HOME, "logs")
 	logFilePath := filepath.Join(logFileDirectory, "cli.log")
 

--- a/components/cli/pkg/util/file_operations.go
+++ b/components/cli/pkg/util/file_operations.go
@@ -359,3 +359,14 @@ func CopyK8sArtifacts(outPath string) {
 	CreateDir(k8sArtifactsDir)
 	CopyDir(filepath.Join(CelleryInstallationDir(), constants.K8S_ARTIFACTS), k8sArtifactsDir)
 }
+
+func CreateCelleryDirStructure()  {
+	celleryHome := filepath.Join(UserHomeDir(), constants.CELLERY_HOME)
+	CreateDir(celleryHome)
+	CreateDir(filepath.Join(celleryHome, "gpc"))
+	CreateDir(filepath.Join(celleryHome, "k8s-artefacts"))
+	CreateDir(filepath.Join(celleryHome, "logs"))
+	CreateDir(filepath.Join(celleryHome, "repo"))
+	CreateDir(filepath.Join(celleryHome, "tmp"))
+	CreateDir(filepath.Join(celleryHome, "vm"))
+}


### PR DESCRIPTION
Add cellery home directory structure creation to cellery root command

Resolves https://github.com/wso2-cellery/sdk/issues/724, https://github.com/wso2-cellery/sdk/issues/649