### PR TITLE
Introduce a flag to view cellery system logs

### DIFF
--- a/components/cli/cmd/cellery/logs.go
+++ b/components/cli/cmd/cellery/logs.go
@@ -51,8 +51,11 @@ func newLogsCommand() *cobra.Command {
 			}
 			return nil
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			commands.RunLogs(args[0], component, syslog)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := commands.RunLogs(args[0], component, syslog); err != nil {
+				return fmt.Errorf("error running cellery log, %v", err)
+			}
+			return nil
 		},
 		Example: "  cellery logs employee\n" +
 			"  cellery logs employee -c salary",

--- a/components/cli/cmd/cellery/logs.go
+++ b/components/cli/cmd/cellery/logs.go
@@ -30,6 +30,7 @@ import (
 
 func newLogsCommand() *cobra.Command {
 	var component string
+	var syslog bool
 	cmd := &cobra.Command{
 		Use:   "logs <instance-name>",
 		Short: "Displays logs for either the cell instance, or a component of a running cell instance.",
@@ -51,11 +52,12 @@ func newLogsCommand() *cobra.Command {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			commands.RunLogs(args[0], component)
+			commands.RunLogs(args[0], component, syslog)
 		},
 		Example: "  cellery logs employee\n" +
 			"  cellery logs employee -c salary",
 	}
 	cmd.Flags().StringVarP(&component, "component", "c", "", "component of the cell")
+	cmd.Flags().BoolVarP(&syslog, "syslog", "s", false, "view system logs")
 	return cmd
 }

--- a/components/cli/pkg/commands/logs.go
+++ b/components/cli/pkg/commands/logs.go
@@ -22,10 +22,9 @@ import (
 	"fmt"
 
 	"github.com/cellery-io/sdk/components/cli/pkg/kubectl"
-	"github.com/cellery-io/sdk/components/cli/pkg/util"
 )
 
-func RunLogs(cellName, componentName string, sysLog bool) {
+func RunLogs(cellName, componentName string, sysLog bool) error {
 	if componentName == "" {
 		var logs string
 		var err error
@@ -36,21 +35,22 @@ func RunLogs(cellName, componentName string, sysLog bool) {
 		}
 
 		if err != nil {
-			util.ExitWithErrorMessage(fmt.Sprintf("Error getting logs for instance %s", cellName), err)
+			return fmt.Errorf(fmt.Sprintf("Error getting logs for instance %s", cellName), err)
 		}
 		if logs == "" {
-			util.ExitWithErrorMessage(fmt.Sprintf("No logs found"), fmt.Errorf("cannot find cell "+
+			return fmt.Errorf(fmt.Sprintf("No logs found"), fmt.Errorf("cannot find cell "+
 				"instance %s", cellName))
 		}
 	} else {
 		logs, err := kubectl.GetComponentLogs(cellName, componentName)
 		if err != nil {
-			util.ExitWithErrorMessage(fmt.Sprintf("Error getting logs for component %s of instance %s",
+			return fmt.Errorf(fmt.Sprintf("Error getting logs for component %s of instance %s",
 				componentName, cellName), err)
 		}
 		if logs == "" {
-			util.ExitWithErrorMessage(fmt.Sprintf("No logs found"), fmt.Errorf("cannot find component "+
+			return fmt.Errorf(fmt.Sprintf("No logs found"), fmt.Errorf("cannot find component "+
 				"%s of cell instance %s", componentName, cellName))
 		}
 	}
+	return nil
 }

--- a/components/cli/pkg/commands/logs.go
+++ b/components/cli/pkg/commands/logs.go
@@ -25,9 +25,16 @@ import (
 	"github.com/cellery-io/sdk/components/cli/pkg/util"
 )
 
-func RunLogs(cellName, componentName string) {
+func RunLogs(cellName, componentName string, sysLog bool) {
 	if componentName == "" {
-		logs, err := kubectl.GetCellLogs(cellName)
+		var logs string
+		var err error
+		if sysLog {
+			logs, err = kubectl.GetCellLogsAllComponents(cellName)
+		} else {
+			logs, err = kubectl.GetCellLogsUserComponents(cellName)
+		}
+
 		if err != nil {
 			util.ExitWithErrorMessage(fmt.Sprintf("Error getting logs for instance %s", cellName), err)
 		}

--- a/components/cli/pkg/kubectl/logs.go
+++ b/components/cli/pkg/kubectl/logs.go
@@ -27,7 +27,20 @@ import (
 	"github.com/cellery-io/sdk/components/cli/pkg/osexec"
 )
 
-func GetCellLogs(cellName string) (string, error) {
+func GetCellLogsUserComponents(cellName string) (string, error) {
+	cmd := exec.Command(constants.KUBECTL,
+		"logs",
+		"-l",
+		constants.GROUP_NAME+"/cell="+cellName+","+constants.GROUP_NAME+"/component",
+		"--all-containers=true",
+	)
+	displayVerboseOutput(cmd)
+	out, err := osexec.GetCommandOutputFromTextFile(cmd)
+	fmt.Print(string(out))
+	return string(out), err
+}
+
+func GetCellLogsAllComponents(cellName string) (string, error) {
 	cmd := exec.Command(constants.KUBECTL,
 		"logs",
 		"-l",


### PR DESCRIPTION
## Purpose
> By default, only show user component logs for the command ```cellery logs <insance-name>``` and introduce -s flag to view logs including cellery system logs

## Goals
> Fix [sdk/issues/853](https://github.com/wso2-cellery/sdk/issues/853)