### PR TITLE
Update cellery build to delete target dir before starting build

### DIFF
--- a/components/cli/pkg/commands/image/build.go
+++ b/components/cli/pkg/commands/image/build.go
@@ -63,6 +63,13 @@ func RunBuild(cli cli.Cli, tag string, fileName string) error {
 	if !fileExist {
 		return fmt.Errorf("file '%s' does not exist", util.Bold(fileName))
 	}
+
+	// Removing the target directory if it exists
+	targetDir := filepath.Join(projectDir, "target")
+	if err = os.RemoveAll(targetDir); err != nil {
+		return fmt.Errorf("failed to cleanup target directory, %v", err)
+	}
+
 	var tempBuildFileName string
 	if err = cli.ExecuteTask("Creating temporary executable bal file", "Failed to create temporary baf file",
 		"", func() error {


### PR DESCRIPTION
## Purpose
> Update cellery build to delete target dir before starting build

## Goals
> Keeping old target directories can cause the build artifacts to be malformed. To avoid this, the target directory was delete before executing the build.

## Approach
> Delete target directory before executing the build.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A